### PR TITLE
handle multiline comments and pre compile regular expression

### DIFF
--- a/w3lib/html.py
+++ b/w3lib/html.py
@@ -78,10 +78,12 @@ def replace_tags(text, token='', encoding=None):
     return _tag_re.sub(token, str_to_unicode(text, encoding))
 
 
+_REMOVECOMMENTS_RE = re.compile(u'<!--.*?-->', re.DOTALL)
 def remove_comments(text, encoding=None):
     """ Remove HTML Comments. """
-    return re.sub('<!--.*?-->', u'', str_to_unicode(text, encoding), re.DOTALL)
-      
+    text = str_to_unicode(text, encoding)
+    return _REMOVECOMMENTS_RE.sub(u'', text)
+
 def remove_tags(text, which_ones=(), keep=(), encoding=None):
     """ Remove HTML Tags only. 
 

--- a/w3lib/tests/test_html.py
+++ b/w3lib/tests/test_html.py
@@ -62,6 +62,7 @@ class HtmlTests(unittest.TestCase):
         # text with comments
         self.assertEqual(remove_comments(u'<!--text with comments-->'), u'')
         self.assertEqual(remove_comments(u'Hello<!--World-->'), u'Hello')
+        self.assertEqual(remove_comments(u'Hello<!--My\nWorld-->'), u'Hello')
 
     def test_remove_tags(self):
         # make sure it always return unicode


### PR DESCRIPTION
remove_comments wasn't handling the case for comments splitted in multiples lines
