### PR TITLE
Encoding detection for empty body

### DIFF
--- a/w3lib/encoding.py
+++ b/w3lib/encoding.py
@@ -114,15 +114,7 @@ def to_unicode(data_str, encoding):
     Characters that cannot be converted will be converted to '\ufffd' (the
     unicode replacement character).
     """
-    data_str.decode(encoding, 'w3lib_replace')
-
-def _enc_unicode(data_str, encoding):
-    """convert the data_str to unicode inserting the unicode replacement
-    character where necessary. 
-    
-    returns (encoding, unicode)
-    """
-    return encoding, data_str.decode(encoding, 'w3lib_replace')
+    return data_str.decode(encoding, 'w3lib_replace')
 
 def html_to_unicode(content_type_header, html_body_str, 
         default_encoding='utf8', auto_detect_fun=None):
@@ -177,12 +169,12 @@ def html_to_unicode(content_type_header, html_body_str,
                 html_body_str = html_body_str[len(bom):]
             else:
                 enc += '-be'
-        return _enc_unicode(html_body_str, enc)
+        return enc, to_unicode(html_body_str, enc)
     if bom_enc is not None:
-        return _enc_unicode(html_body_str[len(bom):], bom_enc)
+        return bom_enc, to_unicode(html_body_str[len(bom):], bom_enc)
     enc = html_body_declared_encoding(html_body_str)
     if enc is None and (auto_detect_fun is not None):
         enc = auto_detect_fun(html_body_str)
     if enc is None:
         enc = default_encoding
-    return _enc_unicode(html_body_str, enc)
+    return enc, to_unicode(html_body_str, enc)

--- a/w3lib/tests/test_encoding.py
+++ b/w3lib/tests/test_encoding.py
@@ -1,5 +1,5 @@
 import unittest, codecs
-from w3lib.encoding import (html_body_declared_encoding, read_bom,
+from w3lib.encoding import (html_body_declared_encoding, read_bom, to_unicode,
         http_content_type_encoding, resolve_encoding, html_to_unicode)
 
 class RequestEncodingTests(unittest.TestCase):
@@ -54,6 +54,16 @@ class CodecsEncodingTestCase(unittest.TestCase):
         self.assertEqual(resolve_encoding('latin1'), 'cp1252')
         self.assertEqual(resolve_encoding(' Latin-1'), 'cp1252')
         self.assertEqual(resolve_encoding('unknown encoding'), None)
+
+
+class UnicodeDecodingTestCase(unittest.TestCase):
+
+    def test_utf8(self):
+        self.assertEqual(to_unicode('\xc2\xa3', 'utf-8'), u'\xa3')
+
+    def test_invalid_utf8(self):
+        self.assertEqual(to_unicode('\xc2\xc2\xa3', 'utf-8'), u'\ufffd\xa3')
+
 
 def ct(charset):
     return "Content-Type: text/html; charset=" + charset if charset else None


### PR DESCRIPTION
Don't fail accessing first byte of empty bodies looking for BOM

(also reuse to_unicode function in html_to_unicode and add tests for it)
