### PR TITLE
Detect encoding for content attr before http-equiv in meta tag

### DIFF
--- a/w3lib/encoding.py
+++ b/w3lib/encoding.py
@@ -21,7 +21,7 @@ _XML_ENCODING_RE = _TEMPLATE % ('encoding', r'(?P<xmlcharset>[\w-]+)')
 
 # check for meta tags, or xml decl. and stop search if a body tag is encountered
 _BODY_ENCODING_RE = re.compile(
-    r'<\s*(?:meta\s+(?:%s\s+%s|%s)|\?xml\s[^>]+%s|body)' % \
+    r'<\s*(?:meta(?:(?:\s+%s|\s+%s){2}|\s+%s)|\?xml\s[^>]+%s|body)' % \
         (_HTTPEQUIV_RE, _CONTENT_RE, _CONTENT2_RE, _XML_ENCODING_RE), re.I)
 
 def html_body_declared_encoding(html_body_str):

--- a/w3lib/tests/test_encoding.py
+++ b/w3lib/tests/test_encoding.py
@@ -31,23 +31,28 @@ class RequestEncodingTests(unittest.TestCase):
         self.assertEqual(None, http_content_type_encoding("something else"))
 
     def test_html_body_declared_encoding(self):
-        format1 = """
-            <meta http-equiv="Content-Type"
-                content="text/html; charset=utf-8">
-        """
-        format2 = """<meta charset="utf-8">"""
-        format3 = """<?xml version="1.0" encoding="utf-8"?>"""
-        format4 = """ bad html still supported < meta http-equiv='Content-Type'
-            content="text/html; charset=utf-8">"""
-        for fragment in (format1, format2, format3, format4):
+        fragments = [
+            # Content-Type as meta http-equiv
+            """<meta http-equiv="content-type" content="text/html;charset=UTF-8" />""",
+            """\n<meta http-equiv="Content-Type"\ncontent="text/html; charset=utf-8">""",
+            """<meta content="text/html; charset=utf-8"\n http-equiv='Content-Type'>""",
+            """ bad html still supported < meta http-equiv='Content-Type'\n content="text/html; charset=utf-8">""",
+            # html5 meta charset
+            """<meta charset="utf-8">""",
+            # xml encoding
+            """<?xml version="1.0" encoding="utf-8"?>""",
+        ]
+        for fragment in fragments:
             encoding = html_body_declared_encoding(fragment)
-            self.assertEqual(encoding, 'utf-8')
+            self.assertEqual(encoding, 'utf-8', fragment)
         self.assertEqual(None, html_body_declared_encoding("something else"))
         self.assertEqual(None, html_body_declared_encoding("""
             <head></head><body>
             this isn't searched
             <meta charset="utf-8">
         """))
+        self.assertEqual(None, html_body_declared_encoding(
+            """<meta http-equiv="Fake-Content-Type-Header" content="text/html; charset=utf-8">"""))
 
 class CodecsEncodingTestCase(unittest.TestCase):
     def test_resolve_encoding(self):


### PR DESCRIPTION
It was handling the common case:

`<meta http-equiv='Content-Type' content='text/html;charset=utf-8>`

but failing to extract charset from still valid:

`<meta content='text/html;charset=utf-8 http-equiv='Content-Type'>`

Also fixes Scrapy issue #123 for master branch (0.15 atm)
