### PR TITLE
Fixed `get_meta_refresh()` - site's encoding should be used to encode urls.

### DIFF
--- a/w3lib/html.py
+++ b/w3lib/html.py
@@ -200,7 +200,7 @@ def get_meta_refresh(text, baseurl='', encoding='utf-8'):
     m = _meta_refresh_re.search(text)
     if m:
         interval = float(m.group('int'))
-        url = safe_url_string(m.group('url').strip(' "\''))
+        url = safe_url_string(m.group('url').strip(' "\''), encoding)
         url = urljoin(baseurl, url)
         return interval, url
     else:

--- a/w3lib/tests/test_html.py
+++ b/w3lib/tests/test_html.py
@@ -219,19 +219,14 @@ although this is inside a cdata! &amp; &quot;</node1><node2>blah&blahblahblahbla
         body = """<meta http-equiv="refresh" content="3; url=other.html">"""
         self.assertEqual(get_meta_refresh(body, baseurl), (3, 'http://example.com/page/other.html'))
 
-        # non-standard encodings (utf-16)
-        baseurl = 'http://example.com'
-        body = """<meta http-equiv="refresh" content="3; url=http://example.com/redirect">"""
-        body = body.decode('ascii').encode('utf-16')
-        self.assertEqual(get_meta_refresh(body, baseurl, 'utf-16'), (3, 'http://example.com/redirect'))
-
         # non-ascii chars in the url (utf8 - default)
+        baseurl = 'http://example.com'
         body = """<meta http-equiv="refresh" content="3; url=http://example.com/to\xc2\xa3">"""
         self.assertEqual(get_meta_refresh(body, baseurl), (3, 'http://example.com/to%C2%A3'))
 
         # non-ascii chars in the url (latin1)
         body = """<meta http-equiv="refresh" content="3; url=http://example.com/to\xa3">"""
-        self.assertEqual(get_meta_refresh(body, baseurl, 'latin1'), (3, 'http://example.com/to%C2%A3'))
+        self.assertEqual(get_meta_refresh(body, baseurl, 'latin1'), (3, 'http://example.com/to%A3'))
 
         # html commented meta refresh header must not directed
         body = """<!--<meta http-equiv="refresh" content="3; url=http://example.com/">-->"""


### PR DESCRIPTION
Removed `non-standard encoding` test - encoding url to utf-16 is ugly and
doesn't prove anything.
