### PR TITLE
add_or_replace_parameter can have ? duplicated

### DIFF
--- a/w3lib/url.py
+++ b/w3lib/url.py
@@ -103,7 +103,7 @@ def add_or_replace_parameter(url, name, new_value, sep='&', url_is_quoted=False)
     """Add or remove a parameter to a given url"""
     def has_querystring(url):
         _, _, _, query, _ = urlparse.urlsplit(url)
-        return bool(query)
+        return bool(query) or url.strip().endswith('?')
 
     parameter = url_query_parameter(url, name, keep_blank_values=1)
     if url_is_quoted:


### PR DESCRIPTION
If you call `add_or_replace_parameter` with a url with a question mark on the end, it will duplicate it.

```
>>> add_or_replace_parameter('http://example.com/index.html?', 'page', '1')
'http://example.com/index.html??page=1'
```

because:

```
>>> url
'http://example.com/index.html?'

>>> urlparse.urlsplit(url)
SplitResult(scheme='http', netloc='www.pcrichard.com', path='/index.html', query='', fragment='')

>>> bool(query)
False

>>> url.strip().endswith('?')
True
```
