### PR TITLE
[MRG] Restore distutils compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,10 +28,9 @@ setup_args = dict(
 
 try:
     from setuptools import setup
+    setup_args['install_requires'] = ['six >= 1.4.1']
 except ImportError:
     from distutils.core import setup
-else:
-    setup_args['install_requires'] = ['six >= 1.4.1']
 
 setup(**setup_args)
 


### PR DESCRIPTION
All other scrapy dependencies are installable without setuptools as far as I know.
