### PR TITLE
Fix doctests + add doctests to tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,3 +11,10 @@ deps =
     six >= 1.4.1
     nose
 commands = nosetests []
+           nosetests --with-doctest w3lib/encoding.py w3lib/form.py \
+                w3lib/html.py w3lib/http.py w3lib/url.py
+
+[testenv:py33]
+# disabling doctests for Py3.x because output of the code changes too much
+# for Py2+Py3 compatible comparison
+commands = nosetests []

--- a/w3lib/encoding.py
+++ b/w3lib/encoding.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Functions for handling encoding of web pages
 """
@@ -38,18 +39,19 @@ def html_body_declared_encoding(html_body_str):
 
     >>> import w3lib.encoding
     >>> w3lib.encoding.html_body_declared_encoding(
-    """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
-             "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-        <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-        <head>
-            <title>Some title</title>
-            <meta http-equiv="content-type" content="text/html;charset=utf-8" />
-        </head>
-        <body>
-        ...
-        </body>
-        </html>""")
+    ... """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+    ...      "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+    ... <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+    ... <head>
+    ...     <title>Some title</title>
+    ...     <meta http-equiv="content-type" content="text/html;charset=utf-8" />
+    ... </head>
+    ... <body>
+    ... ...
+    ... </body>
+    ... </html>""")
     'utf-8'
+    >>>
 
     '''
 
@@ -105,10 +107,12 @@ def resolve_encoding(encoding_alias):
     """Return the encoding that `encoding_alias` maps to, or ``None``
     if the encoding cannot be interpreted
 
+    >>> import w3lib.encoding
     >>> w3lib.encoding.resolve_encoding('latin1')
     'cp1252'
     >>> w3lib.encoding.resolve_encoding('gb_2312-80')
     'gb18030'
+    >>>
 
     """
     c18n_encoding = _c18n_encoding(encoding_alias)
@@ -128,21 +132,23 @@ _BOM_TABLE = [
 _FIRST_CHARS = set(c[0] for (c, _) in _BOM_TABLE)
 
 def read_bom(data):
-    """Read the byte order mark in the text, if present, and
+    r"""Read the byte order mark in the text, if present, and
     return the encoding represented by the BOM and the BOM.
 
-    If no BOM can be detected, (None, None) is returned.
+    If no BOM can be detected, ``(None, None)`` is returned.
 
-    >>> w3lib.encoding.read_bom(b'\\xfe\\xff\\x6c\\x34')
-    ('utf-16-be', '\\xfe\\xff')
-    >>> w3lib.encoding.read_bom(b'\\xff\\xfe\\x34\\x6c')
-    ('utf-16-le', '\\xff\\xfe')
-    >>> w3lib.encoding.read_bom(b'\\x00\\x00\\xfe\\xff\\x00\\x00\\x6c\\x34')
-    ('utf-32-be', '\\x00\\x00\\xfe\\xff')
-    >>> w3lib.encoding.read_bom(b'\\xff\\xfe\\x00\\x00\\x34\\x6c\\x00\\x00')
-    ('utf-32-le', '\\xff\\xfe\\x00\\x00')
-    >>> w3lib.encoding.read_bom(b'\\x01\\x02\\x03\\x04')
+    >>> import w3lib.encoding
+    >>> w3lib.encoding.read_bom(b'\xfe\xff\x6c\x34')
+    ('utf-16-be', '\xfe\xff')
+    >>> w3lib.encoding.read_bom(b'\xff\xfe\x34\x6c')
+    ('utf-16-le', '\xff\xfe')
+    >>> w3lib.encoding.read_bom(b'\x00\x00\xfe\xff\x00\x00\x6c\x34')
+    ('utf-32-be', '\x00\x00\xfe\xff')
+    >>> w3lib.encoding.read_bom(b'\xff\xfe\x00\x00\x34\x6c\x00\x00')
+    ('utf-32-le', '\xff\xfe\x00\x00')
+    >>> w3lib.encoding.read_bom(b'\x01\x02\x03\x04')
     (None, None)
+    >>>
 
     """
 
@@ -167,7 +173,7 @@ def to_unicode(data_str, encoding):
 
 def html_to_unicode(content_type_header, html_body_str,
         default_encoding='utf8', auto_detect_fun=None):
-    """Convert raw html bytes to unicode
+    r'''Convert raw html bytes to unicode
 
     This attempts to make a reasonable guess at the content encoding of the
     html body, following a similar process to a web browser.
@@ -210,22 +216,25 @@ def html_to_unicode(content_type_header, html_body_str,
 
     Examples:
 
-    >>> doc = '''<!DOCTYPE html>
-    <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width" />
-    <title>Creative Commons France</title>
-    <link rel=\'canonical\' href=\'http://creativecommons.fr/\' />
-    <body>
-    <p>Creative Commons est une organisation \\xc3\\xa0 but non lucratif
-    qui a pour dessein de faciliter la diffusion et le partage des oeuvres
-    tout en accompagnant les nouvelles pratiques de cr\\xc3\\xa9ation \\xc3\\xa0 l\\xe2\\x80\\x99\\xc3\\xa8re numerique.</p>
-    </body>
-    </html>'''
-    >>> w3lib.encoding.html_to_unicode(None, doc)
-    ('utf-8', u'<!DOCTYPE html>\\n<head>\\n<meta charset="UTF-8" />\\n<meta name="viewport" content="width=device-width" />\\n<title>Creative Commons France</title>\\n<link rel=\'canonical\' href=\'http://creativecommons.fr/\' />\\n<body>\\n<p>Creative Commons est une organisation \xe0 but non lucratif\\nqui a pour dessein de faciliter la diffusion et le partage des oeuvres \\ntout en accompagnant les nouvelles pratiques de cr\xe9ation \xe0 l\u2019\xe8re numerique.</p>\\n</body>\\n</html>')
+    >>> import w3lib.encoding
+    >>> w3lib.encoding.html_to_unicode(None,
+    ... """<!DOCTYPE html>
+    ... <head>
+    ... <meta charset="UTF-8" />
+    ... <meta name="viewport" content="width=device-width" />
+    ... <title>Creative Commons France</title>
+    ... <link rel='canonical' href='http://creativecommons.fr/' />
+    ... <body>
+    ... <p>Creative Commons est une organisation \xc3\xa0 but non lucratif
+    ... qui a pour dessein de faciliter la diffusion et le partage des oeuvres
+    ... tout en accompagnant les nouvelles pratiques de cr\xc3\xa9ation \xc3\xa0 l\xe2\x80\x99\xc3\xa8re numerique.</p>
+    ... </body>
+    ... </html>""")
+    ('utf-8', u'<!DOCTYPE html>\n<head>\n<meta charset="UTF-8" />\n<meta name="viewport" content="width=device-width" />\n<title>Creative Commons France</title>\n<link rel=\'canonical\' href=\'http://creativecommons.fr/\' />\n<body>\n<p>Creative Commons est une organisation \xe0 but non lucratif\nqui a pour dessein de faciliter la diffusion et le partage des oeuvres\ntout en accompagnant les nouvelles pratiques de cr\xe9ation \xe0 l\u2019\xe8re numerique.</p>\n</body>\n</html>')
+    >>>
 
-    """
+    '''
+
     enc = http_content_type_encoding(content_type_header)
     bom_enc, bom = read_bom(html_body_str)
     if enc is not None:

--- a/w3lib/form.py
+++ b/w3lib/form.py
@@ -8,16 +8,14 @@ from w3lib.util import unicode_to_str
 
 
 def encode_multipart(data):
-    """Encode the given data to be used in a multipart HTTP POST.
+    r"""
 
     .. warning::
 
         This function is deprecated and will be removed in future.
         Please use ``urllib3.filepost.encode_multipart_formdata`` instead.
 
-    Encode the given data to be used in a multipart HTTP POST. Data is a
-    where keys are the field name, and values are either strings or tuples
-    (filename, content) for file uploads.
+    Encode the given data to be used in a multipart HTTP POST.
 
     `data` is a dictionary where keys are the field name, and values are
     either strings or tuples as `(filename, content)` for file uploads.
@@ -29,13 +27,12 @@ def encode_multipart(data):
 
     >>> import w3lib.form
     >>> w3lib.form.encode_multipart({'key': 'value'})
-    ('\\r\\n----------------GHSKFJDLGDS7543FJKLFHRE75642756743254\\r\\nContent-Disposition: form-data; name="key"\\r\\n\\r\\nvalue\\r\\n----------------GHSKFJDLGDS7543FJKLFHRE75642756743254--\\r\\n', '--------------GHSKFJDLGDS7543FJKLFHRE75642756743254')
-
-    >>> w3lib.form.encode_multipart({'key1': 'value1', 'key2': 'value2'})
-    ('\\r\\n----------------GHSKFJDLGDS7543FJKLFHRE75642756743254\\r\\nContent-Disposition: form-data; name="key2"\\r\\n\\r\\nvalue2\\r\\n----------------GHSKFJDLGDS7543FJKLFHRE75642756743254\\r\\nContent-Disposition: form-data; name="key1"\\r\\n\\r\\nvalue1\\r\\n----------------GHSKFJDLGDS7543FJKLFHRE75642756743254--\\r\\n', '--------------GHSKFJDLGDS7543FJKLFHRE75642756743254')
-
-    >>> w3lib.form.encode_multipart({'somekey': ('path/to/filename', b'\\xa1\\xa2\\xa3\\xa4\\r\\n\\r')})
-    ('\\r\\n----------------GHSKFJDLGDS7543FJKLFHRE75642756743254\\r\\nContent-Disposition: form-data; name="somekey"; filename="path/to/filename"\\r\\n\\r\\n\\xa1\\xa2\\xa3\\xa4\\r\\n\\r\\r\\n----------------GHSKFJDLGDS7543FJKLFHRE75642756743254--\\r\\n', '--------------GHSKFJDLGDS7543FJKLFHRE75642756743254')
+    ('\r\n----------------GHSKFJDLGDS7543FJKLFHRE75642756743254\r\nContent-Disposition: form-data; name="key"\r\n\r\nvalue\r\n----------------GHSKFJDLGDS7543FJKLFHRE75642756743254--\r\n', '--------------GHSKFJDLGDS7543FJKLFHRE75642756743254')
+    >>> w3lib.form.encode_multipart({'key1': 'value1', 'key2': 'value2'})   # doctest: +SKIP
+    ('\r\n----------------GHSKFJDLGDS7543FJKLFHRE75642756743254\r\nContent-Disposition: form-data; name="key2"\r\n\r\nvalue2\r\n----------------GHSKFJDLGDS7543FJKLFHRE75642756743254\r\nContent-Disposition: form-data; name="key1"\r\n\r\nvalue1\r\n----------------GHSKFJDLGDS7543FJKLFHRE75642756743254--\r\n', '--------------GHSKFJDLGDS7543FJKLFHRE75642756743254')
+    >>> w3lib.form.encode_multipart({'somekey': ('path/to/filename', b'\xa1\xa2\xa3\xa4\r\n\r')})
+    ('\r\n----------------GHSKFJDLGDS7543FJKLFHRE75642756743254\r\nContent-Disposition: form-data; name="somekey"; filename="path/to/filename"\r\n\r\n\xa1\xa2\xa3\xa4\r\n\r\r\n----------------GHSKFJDLGDS7543FJKLFHRE75642756743254--\r\n', '--------------GHSKFJDLGDS7543FJKLFHRE75642756743254')
+    >>>
 
     """
 

--- a/w3lib/html.py
+++ b/w3lib/html.py
@@ -17,7 +17,7 @@ _meta_refresh_re = re.compile(six.u(r'<meta[^>]*http-equiv[^>]*refresh[^>]*conte
 _cdata_re = re.compile(r'((?P<cdata_s><!\[CDATA\[)(?P<cdata_d>.*?)(?P<cdata_e>\]\]>))', re.DOTALL)
 
 def remove_entities(text, keep=(), remove_illegal=True, encoding='utf-8'):
-    """Remove entities from the given `text` by converting them to their
+    u"""Remove entities from the given `text` by converting them to their
     corresponding unicode character.
 
     `text` can be a unicode string or a byte string encoded in the given
@@ -37,9 +37,10 @@ def remove_entities(text, keep=(), remove_illegal=True, encoding='utf-8'):
 
     >>> import w3lib.html
     >>> w3lib.html.remove_entities(b'Price: &pound;100')
-    u'Price: \\xa3100!'
-    >>> print w3lib.html.remove_entities(b'Price: &pound;100!')
-    Price: £100!
+    u'Price: \\xa3100'
+    >>> print w3lib.html.remove_entities(b'Price: &pound;100')
+    Price: £100
+    >>>
 
     """
 
@@ -93,6 +94,7 @@ def replace_tags(text, token='', encoding=None):
     u'This text contains some tag'
     >>> w3lib.html.replace_tags('<p>Je ne parle pas <b>fran\\xe7ais</b></p>', ' -- ', 'latin-1')
     u' -- Je ne parle pas  -- fran\\xe7ais --  -- '
+    >>>
 
     """
 
@@ -103,8 +105,10 @@ _REMOVECOMMENTS_RE = re.compile(u'<!--.*?-->', re.DOTALL)
 def remove_comments(text, encoding=None):
     """ Remove HTML Comments.
 
+    >>> import w3lib.html
     >>> w3lib.html.remove_comments(b"test <!--textcoment--> whatever")
     u'test  whatever'
+    >>>
 
     """
 
@@ -128,19 +132,23 @@ def remove_tags(text, which_ones=(), keep=(), encoding=None):
 
     Remove all tags:
 
+    >>> import w3lib.html
     >>> doc = '<div><p><b>This is a link:</b> <a href="http://www.example.com">example</a></p></div>'
     >>> w3lib.html.remove_tags(doc)
     u'This is a link: example'
+    >>>
 
     Keep only some tags:
 
     >>> w3lib.html.remove_tags(doc, keep=('div',))
     u'<div>This is a link: example</div>'
+    >>>
 
     Remove only specific tags:
 
     >>> w3lib.html.remove_tags(doc, which_ones=('a','b'))
     u'<div><p>This is a link: example</p></div>'
+    >>>
 
     You can't remove some and keep some:
 
@@ -150,6 +158,7 @@ def remove_tags(text, which_ones=(), keep=(), encoding=None):
       File "/usr/local/lib/python2.7/dist-packages/w3lib/html.py", line 101, in remove_tags
         assert not (which_ones and keep), 'which_ones and keep can not be given at the same time'
     AssertionError: which_ones and keep can not be given at the same time
+    >>>
 
     """
 
@@ -176,9 +185,11 @@ def remove_tags_with_content(text, which_ones=(), encoding=None):
     `which_ones` is a tuple of which tags to remove including their content.
     If is empty, returns the string unmodified.
 
+    >>> import w3lib.html
     >>> doc = '<div><p><b>This is a link:</b> <a href="http://www.example.com">example</a></p></div>'
     >>> w3lib.html.remove_tags_with_content(doc, which_ones=('b',))
     u'<div><p> <a href="http://www.example.com">example</a></p></div>'
+    >>>
 
     """
 

--- a/w3lib/http.py
+++ b/w3lib/http.py
@@ -7,17 +7,20 @@ def headers_raw_to_dict(headers_raw):
 
     For example:
 
-    >>> headers_raw_to_dict("Content-type: text/html\\n\\rAccept: gzip\\n\\n")
+    >>> import w3lib.http
+    >>> w3lib.http.headers_raw_to_dict("Content-type: text/html\\n\\rAccept: gzip\\n\\n")   # doctest: +SKIP
     {'Content-type': ['text/html'], 'Accept': ['gzip']}
 
     Incorrect input:
 
-    >>> headers_raw_to_dict("Content-typt gzip\\n\\n")
+    >>> w3lib.http.headers_raw_to_dict("Content-typt gzip\\n\\n")
     {}
+    >>>
 
     Argument is ``None`` (return ``None``):
 
-    >>> headers_raw_to_dict(None)
+    >>> w3lib.http.headers_raw_to_dict(None)
+    >>>
 
     """
 
@@ -39,17 +42,15 @@ def headers_dict_to_raw(headers_dict):
 
     For example:
 
-    >>> headers_dict_to_raw({'Content-type': 'text/html', 'Accept': 'gzip'})
+    >>> import w3lib.http
+    >>> w3lib.http.headers_dict_to_raw({'Content-type': 'text/html', 'Accept': 'gzip'}) # doctest: +SKIP
     'Content-type: text/html\\r\\nAccept: gzip'
-
-    >>> from twisted.python.util import InsensitiveDict
-    >>> td = InsensitiveDict({'Content-type': ['text/html'], 'Accept': ['gzip']})
-    >>> headers_dict_to_raw(td)
-    'Content-type: text/html\\r\\nAccept: gzip'
+    >>>
 
     Argument is ``None`` (returns ``None``):
 
-    >>> headers_dict_to_raw(None)
+    >>> w3lib.http.headers_dict_to_raw(None)
+    >>>
 
     """
 

--- a/w3lib/url.py
+++ b/w3lib/url.py
@@ -17,17 +17,20 @@ _ALWAYS_SAFE_BYTES = (b'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
 
 
 def urljoin_rfc(base, ref, encoding='utf-8'):
-    """Same as urlparse.urljoin but supports unicode values in base and ref
+    r"""Same as urlparse.urljoin but supports unicode values in base and ref
     parameters (in which case they will be converted to str using the given
     encoding).
 
     Always returns a str.
 
+    >>> import w3lib.url
     >>> w3lib.url.urljoin_rfc('http://www.example.com/path/index.html', u'/otherpath/index2.html')
     'http://www.example.com/otherpath/index2.html'
+    >>>
 
     >>> w3lib.url.urljoin_rfc('http://www.example.com/path/index.html', u'fran\u00e7ais/d\u00e9part.htm')
     'http://www.example.com/path/fran\xc3\xa7ais/d\xc3\xa9part.htm'
+    >>>
 
 
     """
@@ -89,22 +92,27 @@ def url_query_parameter(url, parameter, default=None, keep_blank_values=0):
 
     General case:
 
+    >>> import w3lib.url
     >>> w3lib.url.url_query_parameter("product.html?id=200&foo=bar", "id")
     '200'
+    >>>
 
     Return a default value if the parameter is not found:
 
     >>> w3lib.url.url_query_parameter("product.html?id=200&foo=bar", "notthere", "mydefault")
     'mydefault'
+    >>>
 
     Returns None if `keep_blank_values` not set or 0 (default):
 
     >>> w3lib.url.url_query_parameter("product.html?id=", "id")
+    >>>
 
     Returns an empty string if `keep_blank_values` set to 1:
 
     >>> w3lib.url.url_query_parameter("product.html?id=", "id", keep_blank_values=1)
     ''
+    >>>
 
     """
 
@@ -117,15 +125,18 @@ def url_query_parameter(url, parameter, default=None, keep_blank_values=0):
 def url_query_cleaner(url, parameterlist=(), sep='&', kvsep='=', remove=False, unique=True):
     """Clean URL arguments leaving only those passed in the parameterlist keeping order
 
+    >>> import w3lib.url
     >>> w3lib.url.url_query_cleaner("product.html?id=200&foo=bar&name=wired", ('id',))
     'product.html?id=200'
     >>> w3lib.url.url_query_cleaner("product.html?id=200&foo=bar&name=wired", ['id', 'name'])
     'product.html?id=200&name=wired'
+    >>>
 
     If `unique` is ``False``, do not remove duplicated keys
 
     >>> w3lib.url.url_query_cleaner("product.html?d=1&e=b&d=2&d=3&other=other", ['d'], unique=False)
     'product.html?d=1&d=2&d=3'
+    >>>
 
     If `remove` is ``True``, leave only those **not in parameterlist**.
 
@@ -133,6 +144,7 @@ def url_query_cleaner(url, parameterlist=(), sep='&', kvsep='=', remove=False, u
     'product.html?foo=bar&name=wired'
     >>> w3lib.url.url_query_cleaner("product.html?id=2&foo=bar&name=wired", ['id', 'foo'], remove=True)
     'product.html?name=wired'
+    >>>
 
     """
 
@@ -156,12 +168,14 @@ def url_query_cleaner(url, parameterlist=(), sep='&', kvsep='=', remove=False, u
 def add_or_replace_parameter(url, name, new_value, sep='&', url_is_quoted=False):
     """Add or remove a parameter to a given url
 
+    >>> import w3lib.url
     >>> w3lib.url.add_or_replace_parameter('http://www.example.com/index.php', 'arg', 'v')
     'http://www.example.com/index.php?arg=v'
     >>> w3lib.url.add_or_replace_parameter('http://www.example.com/index.php?arg1=v1&arg2=v2&arg3=v3', 'arg4', 'v4')
     'http://www.example.com/index.php?arg1=v1&arg2=v2&arg3=v3&arg4=v4'
     >>> w3lib.url.add_or_replace_parameter('http://www.example.com/index.php?arg1=v1&arg2=v2&arg3=v3', 'arg3', 'v3new')
     'http://www.example.com/index.php?arg1=v1&arg2=v2&arg3=v3new'
+    >>>
 
     """
 


### PR DESCRIPTION
Used raw docstrings where needed.
Had to skip some tests that depend on internal dictionary key ordering.
Also disabled doctests in `tox.ini` for Python 3.3
