### PR TITLE
PY3 port headers_raw_to_dict and headers_dict_to_raw to Python 3

### DIFF
--- a/w3lib/http.py
+++ b/w3lib/http.py
@@ -1,19 +1,20 @@
 from base64 import urlsafe_b64encode
 
+
 def headers_raw_to_dict(headers_raw):
-    """
-    Convert raw headers (single multi-line string)
+    r"""
+    Convert raw headers (single multi-line bytestring)
     to a dictionary.
 
     For example:
 
     >>> import w3lib.http
-    >>> w3lib.http.headers_raw_to_dict("Content-type: text/html\\n\\rAccept: gzip\\n\\n")   # doctest: +SKIP
+    >>> w3lib.http.headers_raw_to_dict(b"Content-type: text/html\n\rAccept: gzip\n\n")   # doctest: +SKIP
     {'Content-type': ['text/html'], 'Accept': ['gzip']}
 
     Incorrect input:
 
-    >>> w3lib.http.headers_raw_to_dict("Content-typt gzip\\n\\n")
+    >>> w3lib.http.headers_raw_to_dict(b"Content-typt gzip\n\n")
     {}
     >>>
 
@@ -26,26 +27,27 @@ def headers_raw_to_dict(headers_raw):
 
     if headers_raw is None:
         return None
+    headers = headers_raw.splitlines()
+    headers_tuples = [header.split(b':', 1) for header in headers]
     return dict([
         (header_item[0].strip(), [header_item[1].strip()])
-        for header_item
-        in [
-            header.split(':', 1)
-            for header
-            in headers_raw.splitlines()]
-        if len(header_item) == 2])
+        for header_item in headers_tuples
+        if len(header_item) == 2
+    ])
 
 
 def headers_dict_to_raw(headers_dict):
-    """
+    r"""
     Returns a raw HTTP headers representation of headers
 
     For example:
 
     >>> import w3lib.http
-    >>> w3lib.http.headers_dict_to_raw({'Content-type': 'text/html', 'Accept': 'gzip'}) # doctest: +SKIP
+    >>> w3lib.http.headers_dict_to_raw({b'Content-type': b'text/html', b'Accept': b'gzip'}) # doctest: +SKIP
     'Content-type: text/html\\r\\nAccept: gzip'
     >>>
+
+    Note that keys and values must be bytes.
 
     Argument is ``None`` (returns ``None``):
 
@@ -58,12 +60,12 @@ def headers_dict_to_raw(headers_dict):
         return None
     raw_lines = []
     for key, value in headers_dict.items():
-        if isinstance(value, (str, unicode)):
-            raw_lines.append("%s: %s" % (key, value))
+        if isinstance(value, bytes):
+            raw_lines.append(b": ".join([key, value]))
         elif isinstance(value, (list, tuple)):
             for v in value:
-                raw_lines.append("%s: %s" % (key, v))
-    return '\r\n'.join(raw_lines)
+                raw_lines.append(b": ".join([key, v]))
+    return b'\r\n'.join(raw_lines)
 
 
 def basic_auth_header(username, password):

--- a/w3lib/tests/test_http.py
+++ b/w3lib/tests/test_http.py
@@ -1,5 +1,7 @@
 import unittest
-from w3lib.http import basic_auth_header
+from collections import OrderedDict
+from w3lib.http import (basic_auth_header,
+                        headers_dict_to_raw, headers_raw_to_dict)
 
 __doctests__ = ['w3lib.http'] # for trial support
 
@@ -11,3 +13,19 @@ class HttpTests(unittest.TestCase):
         # Check url unsafe encoded header
         self.assertEqual('Basic c29tZXVzZXI6QDx5dTk-Jm8_UQ==',
             basic_auth_header('someuser', '@<yu9>&o?Q'))
+
+    def test_headers_raw_to_dict(self):
+        raw = b"Content-type: text/html\n\rAccept: gzip\n\n"
+        dct = {b'Content-type': [b'text/html'], b'Accept': [b'gzip']}
+        self.assertEqual(headers_raw_to_dict(raw), dct)
+
+    def test_headers_dict_to_raw(self):
+        dct = OrderedDict([
+            (b'Content-type', b'text/html'),
+            (b'Accept', b'gzip')
+        ])
+        self.assertEqual(
+            headers_dict_to_raw(dct),
+            b'Content-type: text/html\r\nAccept: gzip'
+        )
+


### PR DESCRIPTION
It turns out w3lib.http was not ported. Tests passed because there was not enough tests.

The change could be backwards incompatible because these functions now require bytestrings and return bytestrings. But Scrapy always pass bytestrings to them, and in Python 2.x 'strings' are already bytestrings, so it shouldn't break much code.
