### PR TITLE
Fixed headers_dict_to_raw() when a value of integer type is present

### DIFF
--- a/w3lib/http.py
+++ b/w3lib/http.py
@@ -64,7 +64,7 @@ def headers_dict_to_raw(headers_dict):
             raw_lines.append(b": ".join([key, value]))
         elif isinstance(value, (list, tuple)):
             for v in value:
-                raw_lines.append(b": ".join([key, v]))
+                raw_lines.append(b": ".join([key, str(v)]))
     return b'\r\n'.join(raw_lines)
 
 

--- a/w3lib/tests/test_http.py
+++ b/w3lib/tests/test_http.py
@@ -29,3 +29,14 @@ class HttpTests(unittest.TestCase):
             b'Content-type: text/html\r\nAccept: gzip'
         )
 
+        #Integer value found in a FTP response
+        int_dct = OrderedDict([
+            (b'Size', [12345]),
+            (b'Accept', b'gzip')
+        ])
+
+        self.assertEqual(
+            headers_dict_to_raw(int_dct),
+            b'Size: 12345\r\nAccept: gzip'
+        )
+


### PR DESCRIPTION
Hi, I added support to parse numeric values of integer type present in headers. I check other responses and numeric values are always represented by strings, but in this case I received an integer type inside a list from a FTP response.

It was the response I received:

`[('Local Filename', ['']), ('Size', [46896])]`
