### PR TITLE
FIX w3lib.http.basic_auth_header should return bytes

### DIFF
--- a/w3lib/http.py
+++ b/w3lib/http.py
@@ -74,7 +74,7 @@ def basic_auth_header(username, password):
 
     >>> import w3lib.http
     >>> w3lib.http.basic_auth_header('someuser', 'somepass')
-    u'Basic c29tZXVzZXI6c29tZXBhc3M='
+    'Basic c29tZXVzZXI6c29tZXBhc3M='
 
     .. _HTTP Basic Access Authentication (RFC 2617): http://www.ietf.org/rfc/rfc2617.txt
 
@@ -86,4 +86,4 @@ def basic_auth_header(username, password):
         # seems to be the most widely used encoding here. See also:
         # http://greenbytes.de/tech/webdav/draft-ietf-httpauth-basicauth-enc-latest.html
         auth = auth.encode('ISO-8859-1')
-    return 'Basic ' + urlsafe_b64encode(auth).decode('ascii')
+    return b'Basic ' + urlsafe_b64encode(auth)

--- a/w3lib/tests/test_http.py
+++ b/w3lib/tests/test_http.py
@@ -8,10 +8,10 @@ __doctests__ = ['w3lib.http'] # for trial support
 class HttpTests(unittest.TestCase):
 
     def test_basic_auth_header(self):
-        self.assertEqual('Basic c29tZXVzZXI6c29tZXBhc3M=',
+        self.assertEqual(b'Basic c29tZXVzZXI6c29tZXBhc3M=',
                 basic_auth_header('someuser', 'somepass'))
         # Check url unsafe encoded header
-        self.assertEqual('Basic c29tZXVzZXI6QDx5dTk-Jm8_UQ==',
+        self.assertEqual(b'Basic c29tZXVzZXI6QDx5dTk-Jm8_UQ==',
             basic_auth_header('someuser', '@<yu9>&o?Q'))
 
     def test_headers_raw_to_dict(self):


### PR DESCRIPTION
This is probably backwards-incompatible and can break some code! 

Scrapy expects header values to be bytes, but it auto-encodes unicode values to bytes in Headers class, so this change doesn't change anything when the result of basic_auth_header is used as a Headers value.

It also fixes some Python 3.x compatibility issues for Scrapy, e.g. this check: https://github.com/scrapy/scrapy/blob/8fece4b0b8eb8772a07673b4166cdcdb5c017eb8/scrapy/utils/request.py#L67 was incorrect because `request.headers['Authorization']` returns bytes and so it always returned False in Python 3.x.

This change should fix unicode errors on Windows in https://github.com/scrapinghub/shub project.
