### PR TITLE
Add support for resolving base URLs in <base> tags with attributes before href.

### DIFF
--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -250,6 +250,16 @@ class GetBaseUrlTest(unittest.TestCase):
             </html>"""
         self.assertEqual(get_base_url(text, baseurl), 'http://example.org/something')
 
+    def test_tag_name(self):
+        baseurl = u'https://example.org'
+
+        text = u"""\
+            <html>\
+            <head><title>Dummy</title><basefoo href='http://example.org/something' /></head>\
+            <body>blahablsdfsal&amp;</body>\
+            </html>"""
+        self.assertEqual(get_base_url(text, baseurl), 'https://example.org')
+
 
 class GetMetaRefreshTest(unittest.TestCase):
     def test_get_meta_refresh(self):
@@ -324,3 +334,13 @@ class GetMetaRefreshTest(unittest.TestCase):
 
         body = """<meta http-equiv="refresh" content="3.1;URL=index.html" />"""
         self.assertEqual(get_meta_refresh(body, baseurl), (3.1, 'http://example.com/index.html'))
+
+    def test_tag_name(self):
+        baseurl = 'http://example.org'
+        body = """
+            <html>
+            <head><title>Dummy</title><metafoo http-equiv="refresh" content="5;url=http://example.org/newpage" /></head>
+            <body>blahablsdfsal&amp;</body>
+            </html>"""
+        self.assertEqual(get_meta_refresh(body, baseurl), (None, None))
+

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -240,6 +240,16 @@ class GetBaseUrlTest(unittest.TestCase):
             </html>"""
         self.assertEqual(get_base_url(text, baseurl), 'https://noscheme.com/path')
 
+    def test_attributes_before_href(self):
+        baseurl = u'https://example.org'
+
+        text = u"""\
+            <html>\
+            <head><title>Dummy</title><base id='my_base_tag' href='http://example.org/something' /></head>\
+            <body>blahablsdfsal&amp;</body>\
+            </html>"""
+        self.assertEqual(get_base_url(text, baseurl), 'http://example.org/something')
+
 
 class GetMetaRefreshTest(unittest.TestCase):
     def test_get_meta_refresh(self):

--- a/w3lib/html.py
+++ b/w3lib/html.py
@@ -13,7 +13,7 @@ from w3lib.url import safe_url_string
 
 _ent_re = re.compile(r'&(#?(x?))([^&;\s]+);')
 _tag_re = re.compile(r'<[a-zA-Z\/!].*?>', re.DOTALL)
-_baseurl_re = re.compile(six.u(r'<base\s+href\s*=\s*[\"\']\s*([^\"\'\s]+)\s*[\"\']'), re.I)
+_baseurl_re = re.compile(six.u(r'<base[^>]+href\s*=\s*[\"\']\s*([^\"\'\s]+)\s*[\"\']'), re.I)
 _meta_refresh_re = re.compile(six.u(r'<meta[^>]*http-equiv[^>]*refresh[^>]*content\s*=\s*(?P<quote>["\'])(?P<int>(\d*\.)?\d+)\s*;\s*url=(?P<url>.*?)(?P=quote)'), re.DOTALL | re.IGNORECASE)
 _cdata_re = re.compile(r'((?P<cdata_s><!\[CDATA\[)(?P<cdata_d>.*?)(?P<cdata_e>\]\]>))', re.DOTALL)
 

--- a/w3lib/html.py
+++ b/w3lib/html.py
@@ -13,8 +13,8 @@ from w3lib.url import safe_url_string
 
 _ent_re = re.compile(r'&(#?(x?))([^&;\s]+);')
 _tag_re = re.compile(r'<[a-zA-Z\/!].*?>', re.DOTALL)
-_baseurl_re = re.compile(six.u(r'<base[^>]+href\s*=\s*[\"\']\s*([^\"\'\s]+)\s*[\"\']'), re.I)
-_meta_refresh_re = re.compile(six.u(r'<meta[^>]*http-equiv[^>]*refresh[^>]*content\s*=\s*(?P<quote>["\'])(?P<int>(\d*\.)?\d+)\s*;\s*url=(?P<url>.*?)(?P=quote)'), re.DOTALL | re.IGNORECASE)
+_baseurl_re = re.compile(six.u(r'<base\s[^>]*href\s*=\s*[\"\']\s*([^\"\'\s]+)\s*[\"\']'), re.I)
+_meta_refresh_re = re.compile(six.u(r'<meta\s[^>]*http-equiv[^>]*refresh[^>]*content\s*=\s*(?P<quote>["\'])(?P<int>(\d*\.)?\d+)\s*;\s*url=(?P<url>.*?)(?P=quote)'), re.DOTALL | re.IGNORECASE)
 _cdata_re = re.compile(r'((?P<cdata_s><!\[CDATA\[)(?P<cdata_d>.*?)(?P<cdata_e>\]\]>))', re.DOTALL)
 
 def remove_entities(text, keep=(), remove_illegal=True, encoding='utf-8'):


### PR DESCRIPTION
This adds support for finding the base URL when the <base> tag has some other attribute before the href one. According to http://www.w3.org/TR/html5/document-metadata.html#the-base-element and by my understanding http://www.w3.org/TR/html401/struct/links.html#h-12.4 too, the base element can have other attributes as well.
