### PR TITLE
Update meta_refresh regex

### DIFF
--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -344,3 +344,12 @@ class GetMetaRefreshTest(unittest.TestCase):
             </html>"""
         self.assertEqual(get_meta_refresh(body, baseurl), (None, None))
 
+    def test_leading_newline_in_url(self):
+        baseurl = 'http://example.org'
+        body = """
+        <html>
+        <head><title>Dummy</title><meta http-equiv="refresh" content="0; URL=
+http://www.example.org/index.php" />
+        </head>
+        </html>"""
+        self.assertEqual(get_meta_refresh(body, baseurl), (0.0, 'http://www.example.org/index.php'))

--- a/w3lib/html.py
+++ b/w3lib/html.py
@@ -14,7 +14,7 @@ from w3lib.url import safe_url_string
 _ent_re = re.compile(r'&(#?(x?))([^&;\s]+);')
 _tag_re = re.compile(r'<[a-zA-Z\/!].*?>', re.DOTALL)
 _baseurl_re = re.compile(six.u(r'<base\s[^>]*href\s*=\s*[\"\']\s*([^\"\'\s]+)\s*[\"\']'), re.I)
-_meta_refresh_re = re.compile(six.u(r'<meta\s[^>]*http-equiv[^>]*refresh[^>]*content\s*=\s*(?P<quote>["\'])(?P<int>(\d*\.)?\d+)\s*;\s*url=(?P<url>.*?)(?P=quote)'), re.DOTALL | re.IGNORECASE)
+_meta_refresh_re = re.compile(six.u(r'<meta\s[^>]*http-equiv[^>]*refresh[^>]*content\s*=\s*(?P<quote>["\'])(?P<int>(\d*\.)?\d+)\s*;\s*url=\s*(?P<url>.*?)(?P=quote)'), re.DOTALL | re.IGNORECASE)
 _cdata_re = re.compile(r'((?P<cdata_s><!\[CDATA\[)(?P<cdata_d>.*?)(?P<cdata_e>\]\]>))', re.DOTALL)
 
 def remove_entities(text, keep=(), remove_illegal=True, encoding='utf-8'):


### PR DESCRIPTION
I updated the meta_refresh regex to handle spaces, newlines and other characters supported by `\s` between `url=` and the URL 