### PR TITLE
ENH: do not exclude tests from distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+# Include tests into distribution
+recursive-include tests *
+


### PR DESCRIPTION
Those are handy things to be distributed so users (or packagers such as yours truly) could verify correct operation of the library on their system... if accepted here I would appreciate if similar change was applied to scrapy as well