### PR TITLE
[MRG+1] Redirect inside noscript

### DIFF
--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -361,6 +361,7 @@ http://www.example.org/index.php" />
             <head><noscript><meta http-equiv="refresh" content="0;url=http://example.org/javascript_required" /></noscript></head>
             </html>"""
         self.assertEqual(get_meta_refresh(body, baseurl), (None, None))
+        self.assertEqual(get_meta_refresh(body, baseurl, ignore_tags=()), (0.0, "http://example.org/javascript_required"))
 
     def test_inside_script(self):
         baseurl = 'http://example.org'
@@ -369,3 +370,4 @@ http://www.example.org/index.php" />
             <head><script>if(!foobar()){ $('<meta http-equiv="refresh" content="0;url=http://example.org/foobar_required" />').appendTo('body'); }</script></head>
             </html>"""
         self.assertEqual(get_meta_refresh(body, baseurl), (None, None))
+        self.assertEqual(get_meta_refresh(body, baseurl, ignore_tags=()), (0.0, "http://example.org/foobar_required"))

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -353,3 +353,19 @@ http://www.example.org/index.php" />
         </head>
         </html>"""
         self.assertEqual(get_meta_refresh(body, baseurl), (0.0, 'http://www.example.org/index.php'))
+
+    def test_inside_noscript(self):
+        baseurl = 'http://example.org'
+        body = """
+            <html>
+            <head><noscript><meta http-equiv="refresh" content="0;url=http://example.org/javascript_required" /></noscript></head>
+            </html>"""
+        self.assertEqual(get_meta_refresh(body, baseurl), (None, None))
+
+    def test_inside_script(self):
+        baseurl = 'http://example.org'
+        body = """
+            <html>
+            <head><script>if(!foobar()){ $('<meta http-equiv="refresh" content="0;url=http://example.org/foobar_required" />').appendTo('body'); }</script></head>
+            </html>"""
+        self.assertEqual(get_meta_refresh(body, baseurl), (None, None))

--- a/w3lib/html.py
+++ b/w3lib/html.py
@@ -284,7 +284,7 @@ def get_base_url(text, baseurl='', encoding='utf-8'):
         baseurl = moves.urllib.parse.urljoin(baseurl, m.group(1).encode(encoding))
     return safe_url_string(baseurl)
 
-def get_meta_refresh(text, baseurl='', encoding='utf-8'):
+def get_meta_refresh(text, baseurl='', encoding='utf-8', ignore_tags=('script', 'noscript')):
     """Return  the http-equiv parameter of the HTML meta element from the given
     HTML text and return a tuple ``(interval, url)`` where interval is an integer
     containing the delay in seconds (or zero if not present) and url is a
@@ -301,7 +301,7 @@ def get_meta_refresh(text, baseurl='', encoding='utf-8'):
     except UnicodeDecodeError:
         print(text)
         raise
-    text = remove_tags_with_content(text, ('script', 'noscript'))
+    text = remove_tags_with_content(text, ignore_tags)
     text = remove_comments(replace_entities(text))
     m = _meta_refresh_re.search(text)
     if m:

--- a/w3lib/html.py
+++ b/w3lib/html.py
@@ -301,6 +301,7 @@ def get_meta_refresh(text, baseurl='', encoding='utf-8'):
     except UnicodeDecodeError:
         print(text)
         raise
+    text = remove_tags_with_content(text, ('script', 'noscript'))
     text = remove_comments(replace_entities(text))
     m = _meta_refresh_re.search(text)
     if m:


### PR DESCRIPTION
Many websites (e.g: Facebook) redirect to an error page browsers that
don't support JavaScript by using a meta redirect inside a noscript tag
like this:

```
<noscript>
    <meta http-equiv="refresh" content="0; URL=/?_fb_noscript=1"/>
</noscript>
```

This removes noscript and script tags from the source before searching
for the meta tag.