### PR TITLE
Fix uncaught UnicodeDecodeError when decoding entities (Thanks @horva!)

### DIFF
--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -36,6 +36,8 @@ class RemoveEntitiesTest(unittest.TestCase):
         self.assertEqual(replace_entities('a &lt; b &illegal; c &#12345678; six', remove_illegal=True),
                          u'a < b  c  six')
         self.assertEqual(replace_entities('x&#x2264;y'), u'x\u2264y')
+        self.assertEqual(replace_entities('x&#157;y'), u'xy')
+        self.assertEqual(replace_entities('x&#157;y', remove_illegal=False), u'x&#157;y')
 
     def test_browser_hack(self):
         # check browser hack for numeric character references in the 80-9F range

--- a/w3lib/html.py
+++ b/w3lib/html.py
@@ -81,11 +81,11 @@ def replace_entities(text, keep=(), remove_illegal=True, encoding='utf-8'):
             # interpreted by browsers as representing the characters mapped
             # to bytes 80-9F in the Windows-1252 encoding. For more info
             # see: http://en.wikipedia.org/wiki/Character_encodings_in_HTML
-            if 0x80 <= number <= 0x9f:
-                return six.int2byte(number).decode('cp1252')
-
             try:
-                return six.unichr(number)
+                if 0x80 <= number <= 0x9f:
+                    return six.int2byte(number).decode('cp1252')
+                else:
+                    return six.unichr(number)
             except ValueError:
                 pass
 


### PR DESCRIPTION
Only happens for Windows-1252 control entities in the range 0x80-0x9f