### PR TITLE
[MRG+1] Fix typo 'zip_zafe' in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     url='https://github.com/scrapy/w3lib',
     packages=find_packages(exclude=('tests', 'tests.*')),
     include_package_data=True,
-    zip_zafe=False,
+    zip_safe=False,
     platforms=['Any'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Squashing the following `UserWarning`:
```
/usr/lib/python3.4/distutils/dist.py:260: UserWarning: Unknown distribution option: 'zip_zafe'
  warnings.warn(msg)
```

(...unless this option can/should actually be removed? Seems like it wasn't active until now.
Been there since https://github.com/scrapy/w3lib/commit/ac08e )