### PR TITLE
Fix get_base_url for non-ascii urls for Python 3

### DIFF
--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -286,6 +286,28 @@ class GetBaseUrlTest(unittest.TestCase):
             </html>"""
         self.assertEqual(get_base_url(text, baseurl), 'https://example.org')
 
+    def test_get_base_url_utf8(self):
+        baseurl = u'https://example.org'
+
+        text = u"""
+            <html>
+            <head><title>Dummy</title><base href='http://example.org/snowman\u2368' /></head>
+            <body>blahablsdfsal&amp;</body>
+            </html>"""
+        self.assertEqual(get_base_url(text, baseurl),
+                         'http://example.org/snowman%E2%8D%A8')
+
+    def test_get_base_url_latin1(self):
+        baseurl = u'https://example.org'
+
+        text = u"""
+            <html>
+            <head><title>Dummy</title><base href='http://example.org/sterling\u00a3' /></head>
+            <body>blahablsdfsal&amp;</body>
+            </html>"""
+        self.assertEqual(get_base_url(text, baseurl, encoding='latin-1'),
+                         'http://example.org/sterling%A3')
+
 
 class GetMetaRefreshTest(unittest.TestCase):
     def test_get_meta_refresh(self):

--- a/w3lib/html.py
+++ b/w3lib/html.py
@@ -281,11 +281,11 @@ def get_base_url(text, baseurl='', encoding='utf-8'):
     """
 
     text = str_to_unicode(text, encoding)
-    baseurl = unicode_to_str(baseurl, encoding)
     m = _baseurl_re.search(text)
     if m:
-        baseurl = moves.urllib.parse.urljoin(baseurl, m.group(1).encode(encoding))
-    return safe_url_string(baseurl)
+        baseurl = str_to_unicode(baseurl, encoding)
+        baseurl = moves.urllib.parse.urljoin(baseurl, m.group(1))
+    return safe_url_string(unicode_to_str(baseurl, encoding))
 
 def get_meta_refresh(text, baseurl='', encoding='utf-8', ignore_tags=('script', 'noscript')):
     """Return  the http-equiv parameter of the HTML meta element from the given


### PR DESCRIPTION
I added tests by @redapple, and fixed ``get_base_url`` to do urljoin on unicode strings.

The line with ``baseurl = str_to_unicode(baseurl, encoding)`` is required because ``get_base_url`` seems to be expected to work with byte urls as well (``test_get_base_url`` in the same file). I am not sure which encoding to use here, decided to be more permissive to avoid breaking existing python 2 code which might be using utf-8 encoded strings here.

Related to https://github.com/scrapy/scrapy/issues/1783