### PR TITLE
Support pre-releases

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -4,7 +4,29 @@ commit = True
 tag = True
 tag_name = v{new_version}
 
+parse = ^
+	(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
+	(?:(?P<prerel>[abc]|rc|dev)(?P<prerelversion>\d+))?
+serialize = 
+	{major}.{minor}.{patch}{prerel}{prerelversion}
+	{major}.{minor}.{patch}
+
 [bumpversion:file:setup.py]
 
 [bumpversion:file:docs/conf.py]
+
+[bumpversion:part:prerel]
+optional_value = gamma
+values = 
+	dev
+	rc
+	gamma
+
+[bumpversion:part:prerelversion]
+values = 
+	1
+	2
+	3
+
+
 

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,9 +1,8 @@
 [bumpversion]
-current_version = 1.13.0
+current_version = 1.14.0dev1
 commit = True
 tag = True
 tag_name = v{new_version}
-
 parse = ^
 	(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 	(?:(?P<prerel>[abc]|rc|dev)(?P<prerelversion>\d+))?
@@ -27,6 +26,4 @@ values =
 	1
 	2
 	3
-
-
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,7 +53,7 @@ copyright = u'2014, w3lib developers'
 # built documents.
 #
 # The full version, including alpha/beta/rc tags.
-release = '1.13.0'
+release = '1.14.0dev1'
 # The short X.Y version.
 version = '.'.join(release.split('.')[:2])
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='w3lib',
-    version='1.13.0',
+    version='1.14.0dev1',
     license='BSD',
     description='Library of web-related functions',
     author='Scrapy project',


### PR DESCRIPTION
Similar to [what Scrapy does](https://github.com/scrapy/scrapy/wiki/Scrapy-release-procedure).

The idea is to use `bumpversion minor --no-tag` after an official release so that master branch shows a newer version.
I'm not bumpversion-knowledgeable so I copied lines from scrapy's `.bumpversion.cfg`