### PR TITLE
Handle bytes URL with wrong encoding by percent-encoding offending bytes

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -106,6 +106,19 @@ class UrlTests(unittest.TestCase):
         self.assertTrue(isinstance(safeurl, str))
         self.assertEqual(safeurl, "http://www.example.com/%C2%A3?unit=%B5")
 
+    def test_safe_url_string_bytes_input_nonutf8(self):
+        # latin1
+        safeurl = safe_url_string(b"http://www.example.com/\xa3?unit=\xb5")
+        self.assertTrue(isinstance(safeurl, str))
+        self.assertEqual(safeurl, "http://www.example.com/%A3?unit=%B5")
+
+        # cp1251
+        # >>> u'Россия'.encode('cp1251')
+        # '\xd0\xee\xf1\xf1\xe8\xff'
+        safeurl = safe_url_string(b"http://www.example.com/country/\xd0\xee\xf1\xf1\xe8\xff")
+        self.assertTrue(isinstance(safeurl, str))
+        self.assertEqual(safeurl, "http://www.example.com/country/%D0%EE%F1%F1%E8%FF")
+
     def test_safe_url_idna(self):
         # adapted from:
         # https://ssl.icu-project.org/icu-bin/idnbrowser


### PR DESCRIPTION
Related to https://github.com/scrapy/scrapy/pull/1906#issuecomment-206510063

Scrapy 1.0 branch [transforms Unicode URLs in `Requests` init to bytes](https://github.com/scrapy/scrapy/blob/4161a8c82c371ee34841a824ac99de9e2c8cc090/scrapy/http/request/__init__.py#L55) before passing them to `safe_url_string`. Encoding used for this should be UTF8 and not the `encoding` passed at `Request` init.

Example: `(u"http://www.scrapy.org/price/\xa3", encoding='latin1')` becomes `b'http://www.scrapy.org/price/\xa3'` for `safe_url_string` with encoding information (latin1) lost on the way.
Before this patch, UTF-8 is assumed, which fails when converting back to Unicode.

To handle legacy pre-scrapy1.1 code, with wrong passed (or default) encoding, this patch fallbacks to percent-encoding of the bytes that the codec can't handle.