### PR TITLE
Type hints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ env:
   - TOXENV=py33
   - TOXENV=py34
   - TOXENV=py35
+  - TOXENV=mypy2
+  - TOXENV=mypy3
 
 install:
   - pip install -U tox twine wheel codecov

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,5 @@ setup(
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Internet :: WWW/HTTP',
     ],
-    install_requires=['six >= 1.4.1'],
+    install_requires=['six >= 1.4.1', 'typing'],
 )

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -3,6 +3,7 @@ import six
 from w3lib.encoding import (html_body_declared_encoding, read_bom, to_unicode,
         http_content_type_encoding, resolve_encoding, html_to_unicode)
 
+
 class RequestEncodingTests(unittest.TestCase):
     utf8_fragments = [
         # Content-Type as meta http-equiv
@@ -51,6 +52,7 @@ class RequestEncodingTests(unittest.TestCase):
         for fragment in self.utf8_fragments:
             encoding = html_body_declared_encoding(fragment)
             self.assertEqual(encoding, 'utf-8', fragment)
+
         self.assertEqual(None, html_body_declared_encoding(b"something else"))
         self.assertEqual(None, html_body_declared_encoding(b"""
             <head></head><body>
@@ -76,6 +78,11 @@ class RequestEncodingTests(unittest.TestCase):
         self.assertEqual(None, html_body_declared_encoding(
             u"""<meta http-equiv="Fake-Content-Type-Header" content="text/html; charset=utf-8">"""))
 
+    def test_html_body_declared_encoding_aliases(self):
+        fragment = b"""<meta http-equiv="content-type" content="text/html;charset=win-1251"/>"""
+        self.assertEqual("cp1251", html_body_declared_encoding(fragment))
+        self.assertEqual("cp1251", html_body_declared_encoding(fragment.decode('utf8')))
+
 
 class CodecsEncodingTestCase(unittest.TestCase):
     def test_resolve_encoding(self):
@@ -97,8 +104,10 @@ class UnicodeDecodingTestCase(unittest.TestCase):
 def ct(charset):
     return "Content-Type: text/html; charset=" + charset if charset else None
 
+
 def norm_encoding(enc):
     return codecs.lookup(enc).name
+
 
 class HtmlConversionTests(unittest.TestCase):
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, pypy, py33, py34, py35
+envlist = py27, pypy, py33, py34, py35, mypy2, mypy3
 
 [testenv]
 deps =
@@ -12,3 +12,21 @@ deps =
     pytest-cov
 commands =
     py.test --cov=w3lib --cov-report= {posargs:w3lib tests}
+
+
+[testenv:mypy2]
+basepython = python3.5
+deps =
+    mypy-lang
+    typing
+commands =
+    mypy --py2 w3lib tests
+
+
+[testenv:mypy3]
+basepython = python3.5
+deps =
+    mypy-lang
+    typing
+commands =
+    mypy w3lib tests

--- a/w3lib/_types.py
+++ b/w3lib/_types.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+"""
+Which string type to use?
+=========================
+
+1. Variable is an URL ==> use ``str``
+2. Variable is binary; unicode is not accepted ==> use ``bytes``
+3. Variable is text, and it can be only unicode in Python 2 ==> use
+   ``six.text_type``  (or typing.Text??)
+4. Variable is text, but it can be str in Python 2 ==> use w3lib._types.String
+5. Variable can be either bytes or unicode both in Python 2
+   and Python 3 ==> use typing.AnyStr
+6. Variable should be str (==bytes) in Python 2
+   and str (==unicode) in Python 3 ==> use ``str``.
+
+"""
+
+from __future__ import absolute_import
+from typing import Union
+import six
+
+if six.PY2:
+    String = Union[bytes, unicode]
+else:
+    String = str

--- a/w3lib/_types.py
+++ b/w3lib/_types.py
@@ -7,14 +7,14 @@ Which string type to use?
 2. Variable is binary; unicode is not accepted ==> use ``bytes``
 3. Variable is text, and it can be only unicode in Python 2 ==> use
    ``six.text_type``  (or typing.Text??)
-4. Variable is text, but it can be str in Python 2 ==> use w3lib._types.String
+4. Variable is text, but it can be ascii or utf8-encoded str
+   in Python 2 ==> use w3lib._types.String
 5. Variable can be either bytes or unicode both in Python 2
    and Python 3 ==> use typing.AnyStr
 6. Variable should be str (==bytes) in Python 2
    and str (==unicode) in Python 3 ==> use ``str``.
 
 """
-
 from __future__ import absolute_import
 from typing import Union
 import six

--- a/w3lib/encoding.py
+++ b/w3lib/encoding.py
@@ -5,11 +5,10 @@ Functions for handling encoding of web pages
 import re
 import codecs
 import encodings  # type: ignore
-from typing import Optional, Union, AnyStr, Tuple, Callable
+from typing import Optional, AnyStr, Tuple, Callable
 import six
 
 from .util import to_native_str
-from ._types import String
 
 
 _HEADER_ENCODING_RE = re.compile(r'charset=([\w-]+)', re.I)

--- a/w3lib/encoding.py
+++ b/w3lib/encoding.py
@@ -5,7 +5,7 @@ Functions for handling encoding of web pages
 import re
 import codecs
 import encodings  # type: ignore
-from typing import Optional, AnyStr, Tuple, Callable
+from typing import Optional, AnyStr, Tuple, Callable, Union
 import six
 
 from .util import to_native_str
@@ -162,7 +162,7 @@ _FIRST_CHARS = set(c[0] for (c, _) in _BOM_TABLE)
 
 
 def read_bom(data):
-    # type: (bytes) -> Tuple[str, bytes]
+    # type: (bytes) -> Union[Tuple[str, bytes], Tuple[None, None]]
     r"""Read the byte order mark in the text, if present, and
     return the encoding represented by the BOM and the BOM.
 
@@ -271,7 +271,8 @@ def html_to_unicode(content_type_header, html_body_str,
     '''
 
     enc = http_content_type_encoding(content_type_header)
-    bom_enc, bom = read_bom(html_body_str)
+    # FIXME: remove type: ignore when mypy bug is fixed
+    bom_enc, bom = read_bom(html_body_str)  # type: ignore
     if enc is not None:
         # remove BOM if it agrees with the encoding
         if enc == bom_enc:

--- a/w3lib/html.py
+++ b/w3lib/html.py
@@ -7,7 +7,7 @@ import warnings
 import re
 import six
 from six import moves
-from typing import AnyStr, Optional, Tuple, Sequence
+from typing import AnyStr, Optional, Tuple, Sequence, Union
 
 from w3lib.util import to_unicode, to_native_str
 from w3lib.url import safe_url_string
@@ -315,7 +315,7 @@ def get_base_url(text, baseurl='', encoding='utf-8'):
 
 
 def get_meta_refresh(text, baseurl='', encoding='utf-8', ignore_tags=('script', 'noscript')):
-    # type: (AnyStr, str, String, Sequence[String]) -> Tuple[Optional[float], Optional[str]]
+    # type: (AnyStr, str, String, Sequence[String]) -> Union[Tuple[float, str], Tuple[None, None]]
     """Return  the http-equiv parameter of the HTML meta element from the given
     HTML text and return a tuple ``(interval, url)`` where interval is a number
     containing the delay in seconds (or zero if not present) and url is a

--- a/w3lib/html.py
+++ b/w3lib/html.py
@@ -7,15 +7,18 @@ import warnings
 import re
 import six
 from six import moves
+from typing import AnyStr, Optional, Iterable, Tuple, Union, Sequence
 
-from w3lib.util import to_bytes, to_unicode
+from w3lib.util import to_bytes, to_unicode, to_native_str
 from w3lib.url import safe_url_string
+from w3lib._types import String
 
-_ent_re = re.compile(r'&((?P<named>[a-z\d]+)|#(?P<dec>\d+)|#x(?P<hex>[a-f\d]+))(?P<semicolon>;?)', re.IGNORECASE)
-_tag_re = re.compile(r'<[a-zA-Z\/!].*?>', re.DOTALL)
+_ent_re = re.compile(six.u(r'&((?P<named>[a-z\d]+)|#(?P<dec>\d+)|#x(?P<hex>[a-f\d]+))(?P<semicolon>;?)'), re.IGNORECASE)
+_tag_re = re.compile(six.u(r'<[a-zA-Z\/!].*?>'), re.DOTALL)
 _baseurl_re = re.compile(six.u(r'<base\s[^>]*href\s*=\s*[\"\']\s*([^\"\'\s]+)\s*[\"\']'), re.I)
 _meta_refresh_re = re.compile(six.u(r'<meta\s[^>]*http-equiv[^>]*refresh[^>]*content\s*=\s*(?P<quote>["\'])(?P<int>(\d*\.)?\d+)\s*;\s*url=\s*(?P<url>.*?)(?P=quote)'), re.DOTALL | re.IGNORECASE)
 _cdata_re = re.compile(r'((?P<cdata_s><!\[CDATA\[)(?P<cdata_d>.*?)(?P<cdata_e>\]\]>))', re.DOTALL)
+
 
 def remove_entities(text, keep=(), remove_illegal=True, encoding='utf-8'):
     r"""
@@ -35,7 +38,9 @@ def remove_entities(text, keep=(), remove_illegal=True, encoding='utf-8'):
 
     return replace_entities(text, keep, remove_illegal, encoding)
 
+
 def replace_entities(text, keep=(), remove_illegal=True, encoding='utf-8'):
+    # type: (AnyStr, Sequence[String], bool, String) -> six.text_type
     u"""Remove entities from the given `text` by converting them to their
     corresponding unicode character.
 
@@ -93,14 +98,19 @@ def replace_entities(text, keep=(), remove_illegal=True, encoding='utf-8'):
 
     return _ent_re.sub(convert_entity, to_unicode(text, encoding))
 
+
 def has_entities(text, encoding=None):
+    # type: (AnyStr, Optional[String]) -> bool
     return bool(_ent_re.search(to_unicode(text, encoding)))
 
+
 def replace_tags(text, token='', encoding=None):
+    # type: (AnyStr, String, Optional[String]) -> six.text_type
+
     """Replace all markup tags found in the given `text` by the given token.
     By default `token` is an empty string so it just removes all tags.
 
-    `text` can be a unicode string or a regular string encoded as `encoding`
+    `text` can be a unicode string or a byte string encoded as `encoding`
     (or ``'utf-8'`` if `encoding` is not given.)
 
     Always returns a unicode string.
@@ -121,6 +131,7 @@ def replace_tags(text, token='', encoding=None):
 
 _REMOVECOMMENTS_RE = re.compile(u'<!--.*?-->', re.DOTALL)
 def remove_comments(text, encoding=None):
+    # type: (AnyStr, Optional[String]) -> six.text_type
     """ Remove HTML Comments.
 
     >>> import w3lib.html
@@ -130,10 +141,13 @@ def remove_comments(text, encoding=None):
 
     """
 
-    text = to_unicode(text, encoding)
-    return _REMOVECOMMENTS_RE.sub(u'', text)
+    text_unicode = to_unicode(text, encoding)
+    return _REMOVECOMMENTS_RE.sub(u'', text_unicode)
+
 
 def remove_tags(text, which_ones=(), keep=(), encoding=None):
+    # type: (AnyStr, Sequence[String], Sequence[String], Optional[String]) -> six.text_type
+
     """ Remove HTML Tags only.
 
     `which_ones` and `keep` are both tuples, there are four cases:
@@ -182,26 +196,28 @@ def remove_tags(text, which_ones=(), keep=(), encoding=None):
 
     assert not (which_ones and keep), 'which_ones and keep can not be given at the same time'
 
-    which_ones = {tag.lower() for tag in which_ones}
-    keep = {tag.lower() for tag in keep}
+    which_ones_ = {tag.lower() for tag in which_ones}
+    keep_ = {tag.lower() for tag in keep}
 
     def will_remove(tag):
         tag = tag.lower()
-        if which_ones:
-            return tag in which_ones
+        if which_ones_:
+            return tag in which_ones_
         else:
-            return tag not in keep
+            return tag not in keep_
 
     def remove_tag(m):
         tag = m.group(1)
         return u'' if will_remove(tag) else m.group(0)
 
-    regex = '</?([^ >/]+).*?>'
+    regex = u'</?([^ >/]+).*?>'
     retags = re.compile(regex, re.DOTALL | re.IGNORECASE)
 
     return retags.sub(remove_tag, to_unicode(text, encoding))
 
+
 def remove_tags_with_content(text, which_ones=(), encoding=None):
+    # type: (AnyStr, Sequence[String], Optional[String]) -> six.text_type
     """Remove tags and their content.
 
     `which_ones` is a tuple of which tags to remove including their content.
@@ -215,16 +231,18 @@ def remove_tags_with_content(text, which_ones=(), encoding=None):
 
     """
 
-    text = to_unicode(text, encoding)
+    text_unicode = to_unicode(text, encoding)
     if which_ones:
-        tags = '|'.join([r'<%s.*?</%s>|<%s\s*/>' % (tag, tag, tag) for tag in which_ones])
+        tags = u'|'.join([r'<%s.*?</%s>|<%s\s*/>' % (tag, tag, tag) for tag in which_ones])
         retags = re.compile(tags, re.DOTALL | re.IGNORECASE)
-        text = retags.sub(u'', text)
-    return text
+        text_unicode = retags.sub(u'', text_unicode)
+    return text_unicode
 
 
-def replace_escape_chars(text, which_ones=('\n', '\t', '\r'), replace_by=u'', \
-        encoding=None):
+def replace_escape_chars(text, which_ones=('\n', '\t', '\r'), replace_by='',
+                         encoding=None):
+    # type: (AnyStr, Sequence[String], String, Optional[String]) -> six.text_type
+
     """Remove escape characters.
 
     `which_ones` is a tuple of which escape characters we want to remove.
@@ -235,12 +253,15 @@ def replace_escape_chars(text, which_ones=('\n', '\t', '\r'), replace_by=u'', \
 
     """
 
-    text = to_unicode(text, encoding)
+    text_unicode = to_unicode(text, encoding)
     for ec in which_ones:
-        text = text.replace(ec, to_unicode(replace_by, encoding))
-    return text
+        text_unicode = text_unicode.replace(ec, to_unicode(replace_by, encoding))
+    return text_unicode
+
 
 def unquote_markup(text, keep=(), remove_illegal=True, encoding=None):
+    # type: (AnyStr, Sequence[String], bool, Optional[String]) -> six.text_type
+
     """
     This function receives markup as a text (always a unicode string or
     a UTF-8 encoded string) and does the following:
@@ -261,27 +282,29 @@ def unquote_markup(text, keep=(), remove_illegal=True, encoding=None):
             offset = match_e
         yield txt[offset:]
 
-    text = to_unicode(text, encoding)
+    text_unicode = to_unicode(text, encoding)
     ret_text = u''
-    for fragment in _get_fragments(text, _cdata_re):
+    for fragment in _get_fragments(text_unicode, _cdata_re):
         if isinstance(fragment, six.string_types):
             # it's not a CDATA (so we try to remove its entities)
-            ret_text += replace_entities(fragment, keep=keep, remove_illegal=remove_illegal)
+            # XXX: mypy has problems with six.string_types,
+            # had to ignore this type check
+            ret_text += replace_entities(fragment, keep=keep, remove_illegal=remove_illegal)  # type: ignore
         else:
             # it's a CDATA (so we just extract its content)
             ret_text += fragment.group('cdata_d')
     return ret_text
 
+
 def get_base_url(text, baseurl='', encoding='utf-8'):
+    # type: (AnyStr, str, String) -> str
     """Return the base url if declared in the given HTML `text`,
     relative to the given base url.
 
     If no base url is found, the given `baseurl` is returned.
-
     """
-
-    text = to_unicode(text, encoding)
-    m = _baseurl_re.search(text)
+    text_unicode = to_unicode(text, encoding)
+    m = _baseurl_re.search(text_unicode)
     if m:
         return moves.urllib.parse.urljoin(
             safe_url_string(baseurl),
@@ -290,30 +313,30 @@ def get_base_url(text, baseurl='', encoding='utf-8'):
     else:
         return safe_url_string(baseurl)
 
+
 def get_meta_refresh(text, baseurl='', encoding='utf-8', ignore_tags=('script', 'noscript')):
+    # type: (AnyStr, str, String, Sequence[String]) -> Tuple[Optional[float], Optional[str]]
     """Return  the http-equiv parameter of the HTML meta element from the given
-    HTML text and return a tuple ``(interval, url)`` where interval is an integer
+    HTML text and return a tuple ``(interval, url)`` where interval is a number
     containing the delay in seconds (or zero if not present) and url is a
     string with the absolute url to redirect.
 
     If no meta redirect is found, ``(None, None)`` is returned.
 
     """
-
-    if six.PY2:
-        baseurl = to_bytes(baseurl, encoding)
+    baseurl_str = to_native_str(baseurl)
     try:
-        text = to_unicode(text, encoding)
+        text_unicode = to_unicode(text, encoding)
     except UnicodeDecodeError:
         print(text)
         raise
-    text = remove_tags_with_content(text, ignore_tags)
-    text = remove_comments(replace_entities(text))
-    m = _meta_refresh_re.search(text)
+    text_unicode = remove_tags_with_content(text_unicode, ignore_tags)
+    text_unicode = remove_comments(replace_entities(text_unicode))
+    m = _meta_refresh_re.search(text_unicode)
     if m:
         interval = float(m.group('int'))
         url = safe_url_string(m.group('url').strip(' "\''), encoding)
-        url = moves.urllib.parse.urljoin(baseurl, url)
+        url = moves.urllib.parse.urljoin(baseurl_str, url)
         return interval, url
     else:
         return None, None

--- a/w3lib/html.py
+++ b/w3lib/html.py
@@ -7,9 +7,9 @@ import warnings
 import re
 import six
 from six import moves
-from typing import AnyStr, Optional, Iterable, Tuple, Union, Sequence
+from typing import AnyStr, Optional, Tuple, Sequence
 
-from w3lib.util import to_bytes, to_unicode, to_native_str
+from w3lib.util import to_unicode, to_native_str
 from w3lib.url import safe_url_string
 from w3lib._types import String
 

--- a/w3lib/http.py
+++ b/w3lib/http.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from base64 import urlsafe_b64encode
-from typing import Dict, List, Tuple, Optional, Union, AnyStr, Any
+from typing import Dict, List, Optional, Union, Any
 
 from ._types import String
 

--- a/w3lib/http.py
+++ b/w3lib/http.py
@@ -1,7 +1,12 @@
+from __future__ import absolute_import
 from base64 import urlsafe_b64encode
+from typing import Dict, List, Tuple, Optional, Union, AnyStr, Any
+
+from ._types import String
 
 
 def headers_raw_to_dict(headers_raw):
+    # type: (Optional[bytes]) -> Optional[Dict[bytes, List[bytes]]]
     r"""
     Convert raw headers (single multi-line bytestring)
     to a dictionary.
@@ -10,7 +15,7 @@ def headers_raw_to_dict(headers_raw):
 
     >>> import w3lib.http
     >>> w3lib.http.headers_raw_to_dict(b"Content-type: text/html\n\rAccept: gzip\n\n")   # doctest: +SKIP
-    {'Content-type': ['text/html'], 'Accept': ['gzip']}
+    {b'Content-type': [b'text/html'], b'Accept': [b'gzip']}
 
     Incorrect input:
 
@@ -37,6 +42,7 @@ def headers_raw_to_dict(headers_raw):
 
 
 def headers_dict_to_raw(headers_dict):
+    # type: (Optional[Dict[bytes, Union[bytes, List[bytes]]]]) -> Optional[bytes]
     r"""
     Returns a raw HTTP headers representation of headers
 
@@ -69,6 +75,7 @@ def headers_dict_to_raw(headers_dict):
 
 
 def basic_auth_header(username, password):
+    # type: (String, String) -> bytes
     """
     Return an `Authorization` header field value for `HTTP Basic Access Authentication (RFC 2617)`_
 
@@ -79,8 +86,7 @@ def basic_auth_header(username, password):
     .. _HTTP Basic Access Authentication (RFC 2617): http://www.ietf.org/rfc/rfc2617.txt
 
     """
-
-    auth = "%s:%s" % (username, password)
+    auth = "%s:%s" % (username, password)  # type: Any
     if not isinstance(auth, bytes):
         # XXX: RFC 2617 doesn't define encoding, but ISO-8859-1
         # seems to be the most widely used encoding here. See also:

--- a/w3lib/url.py
+++ b/w3lib/url.py
@@ -12,7 +12,7 @@ from six.moves.urllib.parse import (urljoin, urlsplit, urlunsplit,
                                     urldefrag, urlencode, urlparse,
                                     quote, parse_qs, parse_qsl)
 from six.moves.urllib.request import pathname2url, url2pathname  # type: ignore
-from typing import AnyStr, Tuple, Union, Set, Sequence, TypeVar
+from typing import AnyStr, Union, Set, Sequence, TypeVar
 
 from w3lib.util import to_bytes, to_native_str, to_unicode
 from w3lib._types import String

--- a/w3lib/util.py
+++ b/w3lib/util.py
@@ -1,4 +1,8 @@
 import six
+from typing import AnyStr, Optional
+
+from ._types import String
+
 
 def str_to_unicode(text, encoding=None, errors='strict'):
     if encoding is None:
@@ -7,6 +11,7 @@ def str_to_unicode(text, encoding=None, errors='strict'):
         return text.decode(encoding, errors)
     return text
 
+
 def unicode_to_str(text, encoding=None, errors='strict'):
     if encoding is None:
         encoding = 'utf-8'
@@ -14,19 +19,23 @@ def unicode_to_str(text, encoding=None, errors='strict'):
         return text.encode(encoding, errors)
     return text
 
+
 def to_unicode(text, encoding=None, errors='strict'):
+    # type: (AnyStr, Optional[String], String) -> six.text_type
     """Return the unicode representation of a bytes object `text`. If `text`
     is already an unicode object, return it as-is."""
     if isinstance(text, six.text_type):
         return text
-    if not isinstance(text, (bytes, six.text_type)):
+    if not isinstance(text, bytes):
         raise TypeError('to_unicode must receive a bytes, str or unicode '
                         'object, got %s' % type(text).__name__)
     if encoding is None:
         encoding = 'utf-8'
     return text.decode(encoding, errors)
 
+
 def to_bytes(text, encoding=None, errors='strict'):
+    # type: (AnyStr, Optional[String], String) -> bytes
     """Return the binary representation of `text`. If `text`
     is already a bytes object, return it as-is."""
     if isinstance(text, bytes):
@@ -38,7 +47,9 @@ def to_bytes(text, encoding=None, errors='strict'):
         encoding = 'utf-8'
     return text.encode(encoding, errors)
 
+
 def to_native_str(text, encoding=None, errors='strict'):
+    # type: (AnyStr, Optional[String], String) -> str
     """ Return str representation of `text`
     (bytes in Python 2.x and unicode in Python 3.x). """
     if six.PY2:


### PR DESCRIPTION
I've tried to add [PEP-484](https://www.python.org/dev/peps/pep-0484/) type hints in this PR (checked using mypy). They showed how tricky are our string types :) For each string there are several options:
- str
- bytes
- typing.AnyStr
- typing.Text (or six.text_type)
- w3lib._types.String (a custom type I had to add)

There are several interesting points revealed by these type checks, e.g. that `html_body_declared_encoding` only worked in Python 3 because stdlib `encodings.normalize_encoding` accept binary values (I'm not sure this stdlib module is even documented).

---

Update: this PR is rather useless for the end users because of https://github.com/python/mypy/issues/1190; it also adds `typing` runtime dependency which could be good to avoid. Switch to stub files?
