### PR TITLE
Only include relevant files in test directory.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 # Include tests into distribution
-recursive-include tests *
+recursive-include tests *.py *.txt
 


### PR DESCRIPTION
Previous releases contained runtime artifacts due to a greedy machting
recursive-include statement:

    w3lib-1.16.0/tests/__pycache__/test_encoding.cpython-27-PYTEST.pyc
    w3lib-1.16.0/tests/__pycache__/test_form.cpython-27-PYTEST.pyc
    w3lib-1.16.0/tests/__pycache__/test_html.cpython-27-PYTEST.pyc
    w3lib-1.16.0/tests/__pycache__/test_http.cpython-27-PYTEST.pyc
    w3lib-1.16.0/tests/__pycache__/test_url.cpython-27-PYTEST.pyc
    w3lib-1.16.0/tests/__init__.pyc

It is better to use explicit patterns for inclusion.