### PR TITLE
[MRG+1] added a new method to add multiple parameters in url

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -5,7 +5,7 @@ import unittest
 from w3lib.url import (is_url, safe_url_string, safe_download_url,
     url_query_parameter, add_or_replace_parameter, url_query_cleaner,
     file_uri_to_path, parse_data_uri, path_to_file_uri, any_to_uri,
-    urljoin_rfc, canonicalize_url, parse_url)
+    urljoin_rfc, canonicalize_url, parse_url, add_or_replace_parameters)
 from six.moves.urllib.parse import urlparse
 
 
@@ -282,6 +282,16 @@ class UrlTests(unittest.TestCase):
                          'http://example.com/?version=2&pageurl=http%3A%2F%2Fwww.example.com%2Ftest%2F%23fragment%3Dy&param2=value2')
         self.assertEqual(add_or_replace_parameter(url, 'pageurl', 'test'),
                          'http://example.com/?version=1&pageurl=test&param2=value2')
+
+    def test_add_or_replace_parameters(self):
+        url = 'http://domain/test'
+        self.assertEqual(add_or_replace_parameters(url, {'arg': 'v'}),
+                         'http://domain/test?arg=v')
+        url = 'http://domain/test?arg1=v1&arg2=v2&arg3=v3'
+        self.assertEqual(add_or_replace_parameter(url, {'arg4': 'v4'}),
+                         'http://domain/test?arg1=v1&arg2=v2&arg3=v3&arg4=v4')
+        self.assertEqual(add_or_replace_parameter(url, {'arg4': 'v4', 'arg3': 'v3new'}),
+                         'http://domain/test?arg1=v1&arg2=v2&arg3=v3new&arg4=v4')
 
     def test_url_query_cleaner(self):
         self.assertEqual('product.html',

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -288,9 +288,9 @@ class UrlTests(unittest.TestCase):
         self.assertEqual(add_or_replace_parameters(url, {'arg': 'v'}),
                          'http://domain/test?arg=v')
         url = 'http://domain/test?arg1=v1&arg2=v2&arg3=v3'
-        self.assertEqual(add_or_replace_parameter(url, {'arg4': 'v4'}),
+        self.assertEqual(add_or_replace_parameters(url, {'arg4': 'v4'}),
                          'http://domain/test?arg1=v1&arg2=v2&arg3=v3&arg4=v4')
-        self.assertEqual(add_or_replace_parameter(url, {'arg4': 'v4', 'arg3': 'v3new'}),
+        self.assertEqual(add_or_replace_parameters(url, {'arg4': 'v4', 'arg3': 'v3new'}),
                          'http://domain/test?arg1=v1&arg2=v2&arg3=v3new&arg4=v4')
 
     def test_url_query_cleaner(self):

--- a/w3lib/url.py
+++ b/w3lib/url.py
@@ -369,6 +369,7 @@ def parse_data_uri(uri):
 
 
 __all__ = ["add_or_replace_parameter",
+           "add_or_replace_parameters",
            "any_to_uri",
            "canonicalize_url",
            "file_uri_to_path",

--- a/w3lib/url.py
+++ b/w3lib/url.py
@@ -206,7 +206,6 @@ def _add_or_replace_parameters(url, params):
 
     new_args = OrderedDict(args)
     new_args.update(params)
-    new_args = [(k, v) for k, v in new_args.items()]
 
     query = urlencode(new_args)
     return urlunsplit(parsed._replace(query=query))

--- a/w3lib/url.py
+++ b/w3lib/url.py
@@ -229,12 +229,12 @@ def add_or_replace_parameter(url, name, new_value):
 
 
 def add_or_replace_parameters(url, new_parameters):
-    """Add or remove a parameter to a given url
+    """Add or remove a parameters to a given url
 
     >>> import w3lib.url
-    >>> w3lib.url.add_or_replace_parameter('http://www.example.com/index.php', {'arg': 'v'})
+    >>> w3lib.url.add_or_replace_parameters('http://www.example.com/index.php', {'arg': 'v'})
     'http://www.example.com/index.php?arg=v'
-    >>> w3lib.url.add_or_replace_parameter('http://www.example.com/index.php?arg1=v1&arg2=v2&arg3=v3',
+    >>> w3lib.url.add_or_replace_parameters('http://www.example.com/index.php?arg1=v1&arg2=v2&arg3=v3',
     {'arg4': 'v4', 'arg3': 'v3new'})
     'http://www.example.com/index.php?arg1=v1&arg2=v2&arg3=v3new&arg4=v4'
     >>>

--- a/w3lib/url.py
+++ b/w3lib/url.py
@@ -234,8 +234,8 @@ def add_or_replace_parameters(url, new_parameters):
     >>> import w3lib.url
     >>> w3lib.url.add_or_replace_parameters('http://www.example.com/index.php', {'arg': 'v'})
     'http://www.example.com/index.php?arg=v'
-    >>> w3lib.url.add_or_replace_parameters('http://www.example.com/index.php?arg1=v1&arg2=v2&arg3=v3',
-    {'arg4': 'v4', 'arg3': 'v3new'})
+    >>> args = {'arg4': 'v4', 'arg3': 'v3new'}
+    >>> w3lib.url.add_or_replace_parameters('http://www.example.com/index.php?arg1=v1&arg2=v2&arg3=v3', args)
     'http://www.example.com/index.php?arg1=v1&arg2=v2&arg3=v3new&arg4=v4'
     >>>
 

--- a/w3lib/url.py
+++ b/w3lib/url.py
@@ -9,7 +9,7 @@ import re
 import posixpath
 import warnings
 import string
-from collections import namedtuple
+from collections import namedtuple, OrderedDict
 import six
 from six.moves.urllib.parse import (urljoin, urlsplit, urlunsplit,
                                     urldefrag, urlencode, urlparse,
@@ -204,7 +204,7 @@ def _add_or_replace_parameters(url, params):
     parsed = urlsplit(url)
     args = parse_qsl(parsed.query, keep_blank_values=True)
 
-    new_args = dict(args)
+    new_args = OrderedDict(args)
     new_args.update(params)
     new_args = [(k, v) for k, v in new_args.items()]
 


### PR DESCRIPTION
added a new method to add multiple parameters in url

The new function named `add_or_replace_parameters` takes a dictionary of key-value parameters and update that to given url.

```
    >>> import w3lib.url
    >>> w3lib.url.add_or_replace_parameter('http://www.example.com/index.php', {'arg': 'v'})
    'http://www.example.com/index.php?arg=v'
    >>> w3lib.url.add_or_replace_parameter('http://www.example.com/index.php?arg1=v1&arg2=v2&arg3=v3',
    {'arg4': 'v4', 'arg3': 'v3new'})
    'http://www.example.com/index.php?arg1=v1&arg2=v2&arg3=v3new&arg4=v4'
    >>>
```
connects #117
