### PR TITLE
Remove tab and newlines in url.safe_url_string

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -58,8 +58,8 @@ class UrlTests(unittest.TestCase):
         self.assertEqual(safeurl, "http://www.example.com/%A3")
 
         self.assertTrue(isinstance(safe_url_string(b'http://example.com/'), str))
-        
-        # Remove ASCII tab and newlines
+
+    def test_safe_url_string_remove_ascii_tab_and_newlines(self):
         self.assertEqual(safe_url_string("http://example.com/test\n.html"),
                                          "http://example.com/test.html")
         self.assertEqual(safe_url_string("http://example.com/test\t.html"),

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -58,6 +58,20 @@ class UrlTests(unittest.TestCase):
         self.assertEqual(safeurl, "http://www.example.com/%A3")
 
         self.assertTrue(isinstance(safe_url_string(b'http://example.com/'), str))
+        
+        # Remove ASCII tab and newlines
+        self.assertEqual(safe_url_string("http://example.com/test\n.html"),
+                                         "http://example.com/test.html")
+        self.assertEqual(safe_url_string("http://example.com/test\t.html"),
+                                         "http://example.com/test.html")
+        self.assertEqual(safe_url_string("http://example.com/test\r.html"),
+                                         "http://example.com/test.html")
+        self.assertEqual(safe_url_string("http://example.com/test\r.html\n"),
+                                         "http://example.com/test.html")
+        self.assertEqual(safe_url_string("http://example.com/test\r\n.html\t"),
+                                         "http://example.com/test.html")
+        self.assertEqual(safe_url_string("http://example.com/test\a\n.html"),
+                                         "http://example.com/test%07.html")
 
     def test_safe_url_string_unsafe_chars(self):
         safeurl = safe_url_string(r"http://localhost:8001/unwise{,},|,\,^,[,],`?|=[]&[]=|")

--- a/w3lib/url.py
+++ b/w3lib/url.py
@@ -34,11 +34,12 @@ EXTRA_SAFE_CHARS = b'|'  # see https://github.com/scrapy/w3lib/pull/25
 
 _safe_chars = RFC3986_RESERVED + RFC3986_UNRESERVED + EXTRA_SAFE_CHARS + b'%'
 
-remove_tab_newline = re.compile(r'[\t\n\r]')  # see https://url.spec.whatwg.org/#url-parsing
+_ascii_tab_newline_re = re.compile(r'[\t\n\r]')  # see https://infra.spec.whatwg.org/#ascii-tab-or-newline
 
 def safe_url_string(url, encoding='utf8', path_encoding='utf8'):
     """Convert the given URL into a legal URL by escaping unsafe characters
-    according to RFC-3986.
+    according to RFC-3986. Also, ASCII tabs and newlines are removed
+    as per https://url.spec.whatwg.org/#url-parsing.
 
     If a bytes URL is given, it is first converted to `str` using the given
     encoding (which defaults to 'utf-8'). 'utf-8' encoding is used for
@@ -59,7 +60,7 @@ def safe_url_string(url, encoding='utf8', path_encoding='utf8'):
     #   - if the supplied (or default) encoding chokes,
     #     percent-encode offending bytes
     decoded = to_unicode(url, encoding=encoding, errors='percentencode')
-    parts = urlsplit(remove_tab_newline.sub('', decoded))
+    parts = urlsplit(_ascii_tab_newline_re.sub('', decoded))
 
     # IDNA encoding can fail for too long labels (>63 characters)
     # or missing labels (e.g. http://.example.com)

--- a/w3lib/url.py
+++ b/w3lib/url.py
@@ -34,6 +34,8 @@ EXTRA_SAFE_CHARS = b'|'  # see https://github.com/scrapy/w3lib/pull/25
 
 _safe_chars = RFC3986_RESERVED + RFC3986_UNRESERVED + EXTRA_SAFE_CHARS + b'%'
 
+remove_tab_newline = re.compile(r'[\t\n\r]')  # see https://url.spec.whatwg.org/#url-parsing
+
 def safe_url_string(url, encoding='utf8', path_encoding='utf8'):
     """Convert the given URL into a legal URL by escaping unsafe characters
     according to RFC-3986.
@@ -56,8 +58,8 @@ def safe_url_string(url, encoding='utf8', path_encoding='utf8'):
     #     encoded with the supplied encoding (or UTF8 by default)
     #   - if the supplied (or default) encoding chokes,
     #     percent-encode offending bytes
-    parts = urlsplit(to_unicode(url, encoding=encoding,
-                                errors='percentencode'))
+    decoded = to_unicode(url, encoding=encoding, errors='percentencode')
+    parts = urlsplit(remove_tab_newline.sub('', decoded))
 
     # IDNA encoding can fail for too long labels (>63 characters)
     # or missing labels (e.g. http://.example.com)


### PR DESCRIPTION
See https://github.com/scrapy/scrapy/issues/3855

Forgive me if this is an overly naïve approach, I must admit I'm not overly familiar with the formalities of URL definition and handling.