### PR TITLE
fixed url.add_or_replace_parameters to work with multiple value args

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -320,6 +320,13 @@ class UrlTests(unittest.TestCase):
                          'http://example.com/?version=2&pageurl=http%3A%2F%2Fwww.example.com%2Ftest%2F%23fragment%3Dy&param2=value2')
         self.assertEqual(add_or_replace_parameter(url, 'pageurl', 'test'),
                          'http://example.com/?version=1&pageurl=test&param2=value2')
+        url = 'http://example.com/?foo=1&bar=2&foo=1.1'
+        self.assertEqual(add_or_replace_parameter(url, 'baz', '4'),
+                         'http://example.com/?foo=1&bar=2&foo=1.1&baz=4')
+        self.assertEqual(add_or_replace_parameter(url, 'bar', '5'),
+                         'http://example.com/?foo=1&bar=5&foo=1.1')
+        self.assertEqual(add_or_replace_parameter(url, 'foo', '6'),
+                         'http://example.com/?foo=6&bar=2')
 
     def test_add_or_replace_parameters(self):
         url = 'http://domain/test'
@@ -330,6 +337,9 @@ class UrlTests(unittest.TestCase):
                          'http://domain/test?arg1=v1&arg2=v2&arg3=v3&arg4=v4')
         self.assertEqual(add_or_replace_parameters(url, {'arg4': 'v4', 'arg3': 'v3new'}),
                          'http://domain/test?arg1=v1&arg2=v2&arg3=v3new&arg4=v4')
+        url = 'http://domain/test?arg1=v1&arg1=v1.1&arg2=v2&arg3=v3&arg1=v1.2'
+        self.assertEqual(add_or_replace_parameters(url, {'arg1': 'v1new', 'arg4': 'v4', 'arg3': 'v3new'}),
+                         'http://domain/test?arg1=v1new&arg2=v2&arg3=v3new&arg4=v4')
 
     def test_url_query_cleaner(self):
         self.assertEqual('product.html',

--- a/w3lib/url.py
+++ b/w3lib/url.py
@@ -9,7 +9,7 @@ import re
 import posixpath
 import warnings
 import string
-from collections import namedtuple, OrderedDict
+from collections import namedtuple
 import six
 from six.moves.urllib.parse import (urljoin, urlsplit, urlunsplit,
                                     urldefrag, urlencode, urlparse,
@@ -212,9 +212,18 @@ def url_query_cleaner(url, parameterlist=(), sep='&', kvsep='=', remove=False, u
 def _add_or_replace_parameters(url, params):
     parsed = urlsplit(url)
     args = parse_qsl(parsed.query, keep_blank_values=True)
-
-    new_args = OrderedDict(args)
-    new_args.update(params)
+    new_args = []
+    updated_params = set()
+    for name, val in args:
+        if name not in params:
+            new_args.append((name, val))
+            continue
+        if name not in updated_params:
+            updated_params.add(name)
+            new_args.append((name, params[name]))
+    for name, val in params.items():
+        if name not in updated_params:
+            new_args.append((name, val))
 
     query = urlencode(new_args)
     return urlunsplit(parsed._replace(query=query))


### PR DESCRIPTION
It fixes #137 

After this PR approved and merged, I think we can add support to allow multiple values for the new parameters.