### PR TITLE
Remove redundant code and fix pylint

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     platforms=["Any"],
+    python_requires=">=3.6",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: BSD License",

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -149,7 +149,7 @@ class HtmlConversionTests(unittest.TestCase):
         else:
             self.assertTrue(
                 body_unicode in expected_unicode,
-                "%s is not in %s" % (body_unicode, expected_unicode),
+                f"{body_unicode} is not in {expected_unicode}",
             )
 
     def test_content_type_and_conversion(self):

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -124,7 +124,7 @@ class RemoveEntitiesTest(unittest.TestCase):
         ):
             self.assertEqual(replace_entities(entity, encoding="cp1252"), result)
             self.assertEqual(
-                replace_entities("x%sy" % entity, encoding="cp1252"), "x%sy" % result
+                replace_entities(f"x{entity}y", encoding="cp1252"), f"x{result}y"
             )
 
     def test_encoding(self):

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -266,12 +266,8 @@ class UrlTests(unittest.TestCase):
 
         # DNS label too long
         self.assertEqual(
-            safe_url_string(
-                "http://www.{label}.com/résumé?q=résumé".format(label="example" * 11)
-            ),
-            "http://www.{label}.com/r%C3%A9sum%C3%A9?q=r%C3%A9sum%C3%A9".format(
-                label="example" * 11
-            ),
+            safe_url_string(f"http://www.{'example' * 11}.com/résumé?q=résumé"),
+            f"http://www.{'example' * 11}.com/r%C3%A9sum%C3%A9?q=r%C3%A9sum%C3%A9",
         )
 
     def test_safe_url_port_number(self):
@@ -971,12 +967,8 @@ class CanonicalizeUrlTest(unittest.TestCase):
 
         # DNS label too long
         self.assertEqual(
-            canonicalize_url(
-                "http://www.{label}.com/résumé?q=résumé".format(label="example" * 11)
-            ),
-            "http://www.{label}.com/r%C3%A9sum%C3%A9?q=r%C3%A9sum%C3%A9".format(
-                label="example" * 11
-            ),
+            canonicalize_url(f"http://www.{'example' * 11}.com/résumé?q=résumé"),
+            f"http://www.{'example' * 11}.com/r%C3%A9sum%C3%A9?q=r%C3%A9sum%C3%A9",
         )
 
     def test_preserve_nonfragment_hash(self):

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -1033,7 +1033,7 @@ class DataURITests(unittest.TestCase):
 
     def test_unicode_uri(self):
         result = parse_data_uri("data:,é")
-        self.assertEqual(result.data, "é".encode("utf-8"))
+        self.assertEqual(result.data, "é".encode())
 
     def test_default_mediatype(self):
         result = parse_data_uri("data:;charset=iso-8859-7,%be%d3%be")

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, pypy, py35, py36, py37, py38, pypy3, docs, security, flake8, pylint, black
+envlist = py36, py37, py38, pypy3, docs, security, flake8, pylint, black
 
 [testenv]
 deps =

--- a/w3lib/encoding.py
+++ b/w3lib/encoding.py
@@ -45,6 +45,7 @@ _CONTENT2_RE = _TEMPLATE % ("charset", r"(?P<charset2>[\w-]+)")
 _XML_ENCODING_RE = _TEMPLATE % ("encoding", r"(?P<xmlcharset>[\w-]+)")
 
 # check for meta tags, or xml decl. and stop search if a body tag is encountered
+# pylint: disable=consider-using-f-string
 _BODY_ENCODING_PATTERN = (
     r"<\s*(?:meta%s(?:(?:\s+%s|\s+%s){2}|\s+%s)|\?xml\s[^>]+%s|body)"
     % (_SKIP_ATTRS, _HTTPEQUIV_RE, _CONTENT_RE, _CONTENT2_RE, _XML_ENCODING_RE)

--- a/w3lib/encoding.py
+++ b/w3lib/encoding.py
@@ -4,7 +4,7 @@ Functions for handling encoding of web pages
 import re, codecs, encodings
 from typing import Callable, Match, Optional, Tuple, Union, cast
 from w3lib._types import AnyUnicodeError, StrOrBytes
-from w3lib.util import to_native_str
+import w3lib.util
 
 _HEADER_ENCODING_RE = re.compile(r"charset=([\w-]+)", re.I)
 
@@ -92,7 +92,7 @@ def html_body_declared_encoding(html_body_str: StrOrBytes) -> Optional[str]:
             or match.group("xmlcharset")
         )
         if encoding:
-            return resolve_encoding(to_native_str(encoding))
+            return resolve_encoding(w3lib.util.to_unicode(encoding))
 
     return None
 

--- a/w3lib/encoding.py
+++ b/w3lib/encoding.py
@@ -162,7 +162,7 @@ _BOM_TABLE = [
     (codecs.BOM_UTF16_LE, "utf-16-le"),
     (codecs.BOM_UTF8, "utf-8"),
 ]
-_FIRST_CHARS = set(c[0] for (c, _) in _BOM_TABLE)
+_FIRST_CHARS = {c[0] for (c, _) in _BOM_TABLE}
 
 
 def read_bom(data: bytes) -> Union[Tuple[None, None], Tuple[str, bytes]]:

--- a/w3lib/encoding.py
+++ b/w3lib/encoding.py
@@ -2,7 +2,6 @@
 Functions for handling encoding of web pages
 """
 import re, codecs, encodings
-from sys import version_info
 from typing import Callable, Match, Optional, Tuple, Union, cast
 from w3lib._types import AnyUnicodeError, StrOrBytes
 from w3lib.util import to_native_str
@@ -208,9 +207,7 @@ def to_unicode(data_str: bytes, encoding: str) -> str:
     Characters that cannot be converted will be converted to ``\\ufffd`` (the
     unicode replacement character).
     """
-    return data_str.decode(
-        encoding, "replace" if version_info[0:2] >= (3, 3) else "w3lib_replace"
-    )
+    return data_str.decode(encoding, "replace")
 
 
 def html_to_unicode(

--- a/w3lib/html.py
+++ b/w3lib/html.py
@@ -228,9 +228,7 @@ def remove_tags_with_content(
 
     utext = to_unicode(text, encoding)
     if which_ones:
-        tags = "|".join(
-            [r"<%s\b.*?</%s>|<%s\s*/>" % (tag, tag, tag) for tag in which_ones]
-        )
+        tags = "|".join([fr"<{tag}\b.*?</{tag}>|<{tag}\s*/>" for tag in which_ones])
         retags = re.compile(tags, re.DOTALL | re.IGNORECASE)
         utext = retags.sub("", utext)
     return utext

--- a/w3lib/http.py
+++ b/w3lib/http.py
@@ -97,7 +97,7 @@ def basic_auth_header(
 
     """
 
-    auth = "%s:%s" % (to_unicode(username), to_unicode(password))
+    auth = f"{to_unicode(username)}:{to_unicode(password)}"
     # XXX: RFC 2617 doesn't define encoding, but ISO-8859-1
     # seems to be the most widely used encoding here. See also:
     # http://greenbytes.de/tech/webdav/draft-ietf-httpauth-basicauth-enc-latest.html

--- a/w3lib/http.py
+++ b/w3lib/http.py
@@ -1,6 +1,6 @@
 from base64 import urlsafe_b64encode
 from typing import Any, List, MutableMapping, Optional, AnyStr, Sequence, Union, Mapping
-from w3lib.util import to_bytes, to_native_str
+from w3lib.util import to_bytes, to_unicode
 
 HeadersDictInput = Mapping[bytes, Union[Any, Sequence]]
 HeadersDictOutput = MutableMapping[bytes, List[bytes]]
@@ -97,7 +97,7 @@ def basic_auth_header(
 
     """
 
-    auth = "%s:%s" % (to_native_str(username), to_native_str(password))
+    auth = "%s:%s" % (to_unicode(username), to_unicode(password))
     # XXX: RFC 2617 doesn't define encoding, but ISO-8859-1
     # seems to be the most widely used encoding here. See also:
     # http://greenbytes.de/tech/webdav/draft-ietf-httpauth-basicauth-enc-latest.html

--- a/w3lib/url.py
+++ b/w3lib/url.py
@@ -319,7 +319,7 @@ def path_to_file_uri(path: str) -> str:
     x = pathname2url(os.path.abspath(path))
     if os.name == "nt":
         x = x.replace("|", ":")  # http://bugs.python.org/issue5861
-    return "file:///%s" % x.lstrip("/")
+    return f"file:///{x.lstrip('/')}"
 
 
 def file_uri_to_path(uri: str) -> str:
@@ -344,6 +344,7 @@ def any_to_uri(uri_or_path: str) -> str:
 _char = set(map(chr, range(127)))
 
 # RFC 2045 token.
+# pylint: disable=consider-using-f-string
 _token = r"[{}]+".format(
     re.escape(
         "".join(
@@ -359,6 +360,7 @@ _token = r"[{}]+".format(
 )
 
 # RFC 822 quoted-string, without surrounding quotation marks.
+# pylint: disable=consider-using-f-string
 _quoted_string = r"(?:[{}]|(?:\\[{}]))*".format(
     re.escape("".join(_char - {'"', "\\", "\r"})), re.escape("".join(_char))
 )


### PR DESCRIPTION
EOL Python 2.7 and 3.5 were dropped in https://github.com/scrapy/w3lib/pull/168 so we can remove some redundant code and upgrade 
upgrade Python syntax with https://github.com/asottile/pyupgrade `--py36-plus`.

Also add `python_requires` to help pip and fix some deprecation warnings.