### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,22 +15,22 @@ jobs:
     strategy:
       matrix:
         include:
-        - python-version: 3.7
+        - python-version: "3.7"
           env:
             TOXENV: docs
-        - python-version: 3.9
+        - python-version: "3.10"
           env:
             TOXENV: flake8
-        - python-version: 3.9
+        - python-version: "3.10"
           env:
             TOXENV: pylint
-        - python-version: 3.9
+        - python-version: "3.10"
           env:
             TOXENV: security
-        - python-version: 3.9
+        - python-version: "3.10"
           env:
             TOXENV: black
-        - python-version: 3.9
+        - python-version: "3.10"
           env:
             TOXENV: typing
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy3"]
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Internet :: WWW/HTTP",

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
     pytest !=3.1.1, !=3.1.2
     pytest-cov
 commands =
-    py.test \
+    pytest \
         --doctest-modules \
         --cov=w3lib --cov-report=term --cov-report=xml \
         {posargs:w3lib tests}

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, pypy, py35, py36, py37, py38, pypy3, docs, security, flake8, pylint, black
+envlist = py27, pypy, py35, py36, py37, py38, py39, py310, pypy3, docs, security, flake8, pylint, black
 
 [testenv]
 deps =


### PR DESCRIPTION
Python 3.10 was released on 2021-10-04:

* https://discuss.python.org/t/python-3-10-0-is-now-available/10955

---

The pylint errors are fixed in https://github.com/scrapy/w3lib/pull/175.