### PR TITLE
Fix issue #162 add different regex pattern to search for meta tags

### DIFF
--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -669,3 +669,14 @@ http://www.example.org/index.php" />
             get_meta_refresh(body, baseurl, ignore_tags=()),
             (0.0, "http://example.org/foobar_required"),
         )
+
+    def test_redirections_in_different_ordering__in_meta_tag(self):
+        baseurl = 'http://localhost:8000'
+        url1 = '<html><head><meta http-equiv="refresh" content="0;url=dummy.html"></head></html>'
+        url2 = '<html><head><meta content="0;url=dummy.html" http-equiv="refresh"></head></html>'
+        self.assertEqual(
+            get_meta_refresh(url1, baseurl), (0.0, 'http://localhost:8000/dummy.html')
+        )
+        self.assertEqual(
+            get_meta_refresh(url2, baseurl), (0.0, 'http://localhost:8000/dummy.html')
+        )

--- a/w3lib/html.py
+++ b/w3lib/html.py
@@ -21,6 +21,11 @@ _meta_refresh_re = re.compile(
     r'<meta\s[^>]*http-equiv[^>]*refresh[^>]*content\s*=\s*(?P<quote>["\'])(?P<int>(\d*\.)?\d+)\s*;\s*url=\s*(?P<url>.*?)(?P=quote)',
     re.DOTALL | re.IGNORECASE,
 )
+_meta_refresh_re2 = re.compile(
+    r'<meta\s[^>]*content\s*=\s*(?P<quote>["\'])(?P<int>(\d*\.)?\d+)\s*;\s*url=\s*(?P<url>.*?)(?P=quote)\shttp-equiv="refresh"',
+    re.DOTALL | re.IGNORECASE,
+)
+
 _cdata_re = re.compile(
     r"((?P<cdata_s><!\[CDATA\[)(?P<cdata_d>.*?)(?P<cdata_e>\]\]>))", re.DOTALL
 )
@@ -338,7 +343,7 @@ def get_meta_refresh(
         raise
     utext = remove_tags_with_content(utext, ignore_tags)
     utext = remove_comments(replace_entities(utext))
-    m = _meta_refresh_re.search(utext)
+    m = _meta_refresh_re.search(utext) or _meta_refresh_re2.search(utext)
     if m:
         interval = float(m.group("int"))
         url = safe_url_string(m.group("url").strip(" \"'"), encoding)


### PR DESCRIPTION
Changes:

- Add a second regular expression pattern with different ordering in meta tags
- Test that redirection occurs when the attributes of the meta tag are differently ordered