### PR TITLE
declare w3lib as providing type hints

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,9 @@ setup(
     author_email="info@scrapy.org",
     url="https://github.com/scrapy/w3lib",
     packages=find_packages(exclude=("tests", "tests.*")),
+    package_data={
+        "w3lib": ["py.typed"],
+    },
     include_package_data=True,
     zip_safe=False,
     platforms=["Any"],


### PR DESCRIPTION
Type annotations for w3lib were added in https://github.com/scrapy/w3lib/pull/172; however, for mypy to use the when code which depends on w3lib is checked, w3lib should be declared as a package which provides typing information.

See https://peps.python.org/pep-0561/.

This could potentially cause typing checks for packages which depend on w3lib to start failing, either because of typing issues with this code, or because we made some mistakes in w3lib types. But I think that's the intended behavior :)
