### PR TITLE
Changelog

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,7 @@ recursive-include docs Makefile make.bat conf.py *.rst
 
 # Miscellaneous assets
 include LICENSE
+include NEWS
 include README.rst
 include pytest.ini
 include tox.ini

--- a/NEWS
+++ b/NEWS
@@ -24,7 +24,7 @@ Deprecation removals (#169):
 The following functions are deprecated, and will be removed in future releases
 (#170):
 
-- `w3lib.util.str_to_unicode``
+- ``w3lib.util.str_to_unicode``
 - ``w3lib.util.unicode_to_str``
 - ``w3lib.util.to_native_str``
 

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,46 @@
 w3lib release notes
 ===================
 
+2.0.0 (to be released)
+----------------------
+
+Backwards incompatible changes:
+
+- Python 2 is no longer supported; Python 3.6+ is required now (#168, #175).
+- :func:`w3lib.url.safe_url_string` and :func:`w3lib.url.canonicalize_url`
+  no longer convert "%23" to "#" when it appears in URl path. This is a bug
+  fix. It's listed as a backwards incomatible change because in some
+  cases :func:`w3lib.url.canonicalize_url` output is going to change,
+  and so, if this output is used to generate URL fingerprints, fingerprints
+  might be incompatible with those created with the previous w3lib versions
+  (#141).
+
+Deprecation removals (#169):
+
+- ``w3lib.form`` module is removed.
+- ``w3lib.html.remove_entities`` function is removed.
+- ``w3lib.url.urljoin_rfc`` function is removed.
+
+The following functions are deprecated, and will be removed in future releases
+(#170):
+
+- `w3lib.util.str_to_unicode``
+- ``w3lib.util.unicode_to_str``
+- ``w3lib.util.to_native_str``
+
+Other improvements and bug fixes:
+
+- Type annotations are added (#172, #184).
+- Added support for Python 3.9 and 3.10 (#168, #176).
+- Fixed :func:`w3lib.html.get_meta_refresh` for ``<meta>`` tags where
+  ``http-equiv`` is written after ``content`` (#179).
+- Fixed :func:`w3lib.url.safe_url_string` for IDNA domains with ports (#174).
+- :func:`w3lib.url.url_query_cleaner` no longer adds an unneeded ``#`` when
+  ``keep_fragments=True`` is passed, and URL doesn't have a fragment (#159).
+- Removed a workaround for ancient pathname2url bug (#142)
+- CI is migrated to Github Actions (#166, #177); other CI improvements (#160, #182).
+- Code is formatted using black (#173)
+
 1.22.0 (2020-05-13)
 -------------------
 


### PR DESCRIPTION
I think we should release 2.0.0, because Python 2 compat is removed, and there are some deprecation removals.
