### PR TITLE
changing basic_auth_header flavor to b64encode instead of urlsafe_b64encode

### DIFF
--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -17,7 +17,7 @@ class HttpTests(unittest.TestCase):
         )
         # Check url unsafe encoded header
         self.assertEqual(
-            b"Basic c29tZXVzZXI6QDx5dTk-Jm8_UQ==",
+            b"Basic c29tZXVzZXI6QDx5dTk+Jm8/UQ==",
             basic_auth_header("someuser", "@<yu9>&o?Q"),
         )
 
@@ -28,7 +28,7 @@ class HttpTests(unittest.TestCase):
         )
         # default encoding (ISO-8859-1)
         self.assertEqual(
-            b"Basic c29t5nVz6HI6c_htZXDkc3M=", basic_auth_header("somæusèr", "sømepäss")
+            b"Basic c29t5nVz6HI6c/htZXDkc3M=", basic_auth_header("somæusèr", "sømepäss")
         )
 
     def test_headers_raw_dict_none(self):

--- a/w3lib/http.py
+++ b/w3lib/http.py
@@ -1,4 +1,4 @@
-from base64 import urlsafe_b64encode
+from base64 import b64encode
 from typing import Any, List, MutableMapping, Optional, AnyStr, Sequence, Union, Mapping
 from w3lib.util import to_bytes, to_unicode
 
@@ -101,4 +101,4 @@ def basic_auth_header(
     # XXX: RFC 2617 doesn't define encoding, but ISO-8859-1
     # seems to be the most widely used encoding here. See also:
     # http://greenbytes.de/tech/webdav/draft-ietf-httpauth-basicauth-enc-latest.html
-    return b"Basic " + urlsafe_b64encode(to_bytes(auth, encoding=encoding))
+    return b"Basic " + b64encode(to_bytes(auth, encoding=encoding))


### PR DESCRIPTION
Fixes #181