### PR TITLE
187 safe url string already encoded user pass

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -352,12 +352,12 @@ class UrlTests(unittest.TestCase):
 
         self.assertEqual(
             safe_url_string("http://%user:%pass@host"),
-            "http://%user:%pass@host",
+            "http://%25user:%25pass@host",
         )
 
         self.assertEqual(
             safe_url_string("http://%26user:%26pass@host"),
-            "http://%26user:%26pass@host",
+            "http://&user:&pass@host",
         )
 
         self.assertEqual(
@@ -372,7 +372,7 @@ class UrlTests(unittest.TestCase):
 
         self.assertEqual(
             safe_url_string("http://%25%26user:%25%26pass@host"),
-            "http://%25%26user:%25%26pass@host",
+            "http://%25&user:%25&pass@host",
         )
 
     def test_safe_download_url(self):

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -344,6 +344,37 @@ class UrlTests(unittest.TestCase):
             "ftp://admin:%7C%25@example.com",
         )
 
+    def test_safe_url_string_user_and_pass_percentage_encoded(self):
+        self.assertEqual(
+            safe_url_string("http://%25user:%25pass@host"),
+            "http://%25user:%25pass@host",
+        )
+
+        self.assertEqual(
+            safe_url_string("http://%user:%pass@host"),
+            "http://%user:%pass@host",
+        )
+
+        self.assertEqual(
+            safe_url_string("http://%26user:%26pass@host"),
+            "http://%26user:%26pass@host",
+        )
+
+        self.assertEqual(
+            safe_url_string("http://%2525user:%2525pass@host"),
+            "http://%2525user:%2525pass@host",
+        )
+
+        self.assertEqual(
+            safe_url_string("http://%2526user:%2526pass@host"),
+            "http://%2526user:%2526pass@host",
+        )
+
+        self.assertEqual(
+            safe_url_string("http://%25%26user:%25%26pass@host"),
+            "http://%25%26user:%25%26pass@host",
+        )
+
     def test_safe_download_url(self):
         self.assertEqual(
             safe_download_url("http://www.example.org"), "http://www.example.org/"

--- a/w3lib/url.py
+++ b/w3lib/url.py
@@ -30,7 +30,7 @@ from urllib.parse import (
     urlparse,
     urlsplit,
     urlunparse,
-    urlunsplit,
+    urlunsplit, unquote,
 )
 from urllib.parse import _coerce_args  # type: ignore
 from urllib.request import pathname2url, url2pathname
@@ -105,11 +105,11 @@ def safe_url_string(
     netloc_bytes = b""
     if username is not None or password is not None:
         if username is not None:
-            safe_username = quote(username, RFC3986_USERINFO_SAFE_CHARS)
+            safe_username = quote(unquote(username), RFC3986_USERINFO_SAFE_CHARS)
             netloc_bytes += safe_username.encode(encoding)
         if password is not None:
             netloc_bytes += b":"
-            safe_password = quote(password, RFC3986_USERINFO_SAFE_CHARS)
+            safe_password = quote(unquote(password), RFC3986_USERINFO_SAFE_CHARS)
             netloc_bytes += safe_password.encode(encoding)
         netloc_bytes += b"@"
     if hostname is not None:


### PR DESCRIPTION
#187 

using `urllib.unquote()` on the username and password, before `urllib.quote()` solves the % issue.
Nevertheless, I am not sure the current behavior displayed for %26 -> & is the desirable one. 