### PR TITLE
Use latest version of Ubuntu

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         include:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   tests:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11.0-rc.2", "pypy3"]


### PR DESCRIPTION
All workflows of Scrapy org runs on [`ubuntu-latest`](https://github.com/search?o=desc&q=org%3Ascrapy+runs-on&s=indexed&type=Code) runner, except for w3lib and [tests](https://github.com/scrapy/scrapyd/blob/master/.github/workflows/tests.yml) workflow of [scrapyd](https://github.com/scrapy/scrapyd) that's is being handled [here](https://github.com/scrapy/scrapyd/pull/457)