### PR TITLE
fix tox 4 compatibility

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
     pytest !=3.1.1, !=3.1.2
     pytest-cov
 commands =
-    pytest \
+    python -m pytest \
         --doctest-modules \
         --cov=w3lib --cov-report=term --cov-report=xml \
         {posargs:w3lib tests}
@@ -52,12 +52,8 @@ deps =
 commands =
     black {posargs:--check conftest.py setup.py tests w3lib}
 
-[docs]
+[testenv:docs]
 changedir = docs
 deps = -rdocs/requirements.txt
-
-[testenv:docs]
-changedir = {[docs]changedir}
-deps = {[docs]deps}
 commands =
     sphinx-build -W -b html . {envtmpdir}/html


### PR DESCRIPTION
I think we need o do it before the release, because CI is failing.