### PR TITLE
Update intersphinx URLs.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -252,8 +252,8 @@ texinfo_documents = [
 intersphinx_mapping = {
     "pytest": ("https://docs.pytest.org/en/latest", None),
     "python": ("https://docs.python.org/3", None),
-    "scrapy": ("https://scrapy.readthedocs.io/en/latest", None),
-    "tox": ("https://tox.readthedocs.io/en/latest", None),
+    "scrapy": ("https://docs.scrapy.org/en/latest", None),
+    "tox": ("https://tox.wiki/en/latest", None),
 }
 
 


### PR DESCRIPTION
> intersphinx inventory has moved: https://tox.readthedocs.io/en/latest/objects.inv -> https://tox.wiki/en/latest/objects.inv
> intersphinx inventory has moved: https://scrapy.readthedocs.io/en/latest/objects.inv -> https://docs.scrapy.org/en/latest/objects.inv