### PR TITLE
test_url.py: handle 3.9 and 3.10 for http://[2a01:5cc0:1:2:3:4] testcase

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -420,7 +420,11 @@ KNOWN_SAFE_URL_STRING_URL_ISSUES = {
     # (%) are not escaped.
     f"a://example.com#{FRAGMENT_TO_ENCODE}",
 }
-if sys.version_info < (3, 11, 4):
+if (
+    sys.version_info < (3, 9, 21)
+    or (sys.version_info[:2] == (3, 10) and sys.version_info < (3, 10, 16))
+    or (sys.version_info[:2] == (3, 11) and sys.version_info < (3, 11, 4))
+):
     KNOWN_SAFE_URL_STRING_URL_ISSUES.add("http://[2a01:5cc0:1:2:3:4]")  # Invalid IPv6
 
 


### PR DESCRIPTION
The fix for https://github.com/python/cpython/issues/103848 / CVE-2024-11168 also got backported to 3.9.21 and 3.10.16, so we cannot add that testcase for these versions either.