### PR TITLE
fix(url): keep quoted percent sign encoded in canonicalize_url

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -1479,6 +1479,17 @@ class TestCanonicalizeUrl:
         )
         assert canonicalize_url("http://foo.com/AC%2FDC/") == "http://foo.com/AC%2FDC/"
 
+    def test_quoted_percent_sign(self):
+        # a quoted percent sign (%25) must stay encoded, not decode to a bare %
+        assert (
+            canonicalize_url("http://foo.com/cmp/Supermercados-Dia%25")
+            == "http://foo.com/cmp/Supermercados-Dia%25"
+        )
+        assert (
+            canonicalize_url("http://foo.com/100%25/path")
+            == "http://foo.com/100%25/path"
+        )
+
     def test_canonicalize_urlparsed(self):
         # canonicalize_url() can be passed an already urlparse'd URL
         assert (

--- a/w3lib/url.py
+++ b/w3lib/url.py
@@ -722,7 +722,8 @@ def _unquotepath(path: str) -> bytes:
     # percent-escaped characters, they get lost.
     # e.g., '%a3' becomes 'REPLACEMENT CHARACTER' (U+FFFD)
     return _unquote(
-        path.replace("%2f", "%252F")
+        path.replace("%25", "%2525")
+        .replace("%2f", "%252F")
         .replace("%2F", "%252F")
         .replace("%3f", "%253F")
         .replace("%3F", "%253F")


### PR DESCRIPTION
Fixes #131. `_unquotepath` decoded `%25` into a bare `%`, so `canonicalize_url("http://foo.com/cmp/Supermercados-Dia%25")` returned a path ending in an invalid lone `%`. This protects `%25` the same way `%2f`/`%3f` are already protected, keeping it encoded. Added a regression test.