### PR TITLE
Release notes for 2.5.0

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,24 @@
 w3lib release notes
 ===================
 
+2.5.0 (unreleased)
+------------------
+
+- Significantly improved performance of URL-processing functions, including
+  :func:`~w3lib.url.safe_url_string`, :func:`~w3lib.url.canonicalize_url`,
+  :func:`~w3lib.url.url_query_cleaner`, :func:`~w3lib.url.add_or_replace_parameter`,
+  and others (#256, #257).
+
+- Improved performance of :func:`~w3lib.html.remove_tags`,
+  :func:`~w3lib.html.remove_tags_with_content`,
+  :func:`~w3lib.html.unquote_markup`, and
+  :func:`~w3lib.html.get_meta_refresh` (#256).
+
+- :func:`~w3lib.html.get_meta_refresh` no longer prints HTML content to
+  stdout when a :exc:`UnicodeDecodeError` is raised (#256).
+
+- Added benchmarks for URL, HTML, and encoding functions (#247).
+
 2.4.1 (2026-03-20)
 ------------------
 

--- a/NEWS
+++ b/NEWS
@@ -105,6 +105,12 @@ Security and correctness fixes:
   the euro sign when the encoding is GB18030, matching the WHATWG Encoding
   Standard (#300).
 
+- :func:`~w3lib.html.get_meta_refresh` no longer prints the HTML content it
+  was given to stdout when a :exc:`UnicodeDecodeError` is raised (#256).
+
+- Tests, benchmarking and CI improvements (#247, #259, #262, #281, #296,
+  #304).
+
 2.4.1 (2026-03-20)
 ------------------
 

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,110 @@
 w3lib release notes
 ===================
 
+2.5.0 (unreleased)
+------------------
+
+New features:
+
+- Added support for Python 3.15 (#295).
+
+- Added :func:`~w3lib.url.add_http_if_no_scheme`, ported from Scrapy, which
+  adds ``http`` as the default scheme to a URL that has none (#309).
+
+- ``w3lib.url.parse_qsl_to_bytes``, :func:`~w3lib.url.url_query_parameter`,
+  :func:`~w3lib.url.add_or_replace_parameter`,
+  :func:`~w3lib.url.add_or_replace_parameters` and
+  :func:`~w3lib.url.canonicalize_url` now accept a *separator* (or
+  *query_separator* for :func:`~w3lib.url.canonicalize_url`) keyword argument,
+  to support query strings that use a separator other than ``&`` (#167).
+
+- Improved the performance of most :mod:`w3lib.html` functions (#256), and of
+  most :mod:`w3lib.url` functions, :func:`~w3lib.url.safe_url_string` in
+  particular being 4.2x faster (#257).
+
+Security and correctness fixes:
+
+- :func:`~w3lib.url.safe_url_string`, :func:`~w3lib.url.canonicalize_url` and
+  ``w3lib.url.parse_url`` no longer disagree with how browsers and
+  :mod:`urllib.parse` read a URL in the following cases, some of which could
+  let a URL resolve to a different host or path than the one these functions
+  reported:
+
+    - A scheme starting with a digit or a symbol is no longer accepted; a
+      scheme must now start with a letter (#278).
+
+    - ``\`` is now treated like ``/`` in the authority and path of
+      special-scheme URLs (#285).
+
+    - A stray ``[`` or ``]`` outside the authority no longer raises an
+      exception or gets misread as part of an IPv6 host (#277).
+
+    - The query and fragment of an authority-less relative URL, such as
+      ``a?b`` or ``a#f``, are no longer merged into the path (#274).
+
+    - Percent-encoded unreserved characters (e.g. ``%41``) in query
+      parameter names and values are now decoded, so equivalent URLs no
+      longer canonicalize differently (#273).
+
+    - ASCII tab, carriage return and line feed characters are now stripped
+      from the whole URL, including the host, for both ``str`` and ``bytes``
+      input (#279, #301).
+
+    - An NFKC-normalized backslash in the host is now rejected, like other
+      normalized authority delimiters already were (#280).
+
+    - The fragment of a URL with an empty path and a query, such as
+      ``http://example.com?a=b#frag``, is no longer folded into the query
+      (#272).
+
+    - A path segment is now only split into path and parameters on a
+      semicolon in the *last* segment, matching browsers, instead of on the
+      first semicolon found anywhere in the path (#290).
+
+  Additionally, :func:`~w3lib.url.safe_url_string` now adds a ``/`` path to a
+  URL that has a query but no path, since some HTTP clients otherwise send
+  the query alone as the request target (#297).
+
+- Fixed excessive backtracking on malformed input, which could be used for
+  denial of service, in :func:`~w3lib.html.get_base_url` (#264),
+  :func:`~w3lib.html.get_meta_refresh` (#266, #288),
+  :func:`~w3lib.html.remove_tags_with_content` (#271),
+  :func:`~w3lib.html.replace_tags` and :func:`~w3lib.html.remove_tags` (#268,
+  #286), and :func:`~w3lib.html.unquote_markup` on unclosed CDATA sections
+  (#289).
+
+- :func:`~w3lib.html.get_base_url` no longer picks up a ``<base>`` tag
+  written as text inside ``<script>`` or ``<noscript>``, where a browser
+  would ignore it (#303).
+
+- :func:`~w3lib.url.parse_data_uri` no longer accepts a scheme that merely
+  starts with ``data``, such as ``database:`` (#276).
+
+- :func:`~w3lib.html.get_meta_refresh` now detects a ``<meta>`` refresh tag
+  left unterminated by a closing ``>`` (#298), and no longer treats a
+  ``<script>`` or ``<noscript>`` element as closed only by a bare
+  ``</script>``, now also recognizing a closing tag followed by whitespace,
+  ``/`` or another token (#302).
+
+- :func:`~w3lib.html.replace_entities` and :func:`~w3lib.html.get_meta_refresh`
+  now only treat ASCII digits as numeric character references and refresh
+  intervals, matching browsers (#292).
+
+- :func:`~w3lib.encoding.http_content_type_encoding` now recognizes a quoted
+  ``charset`` parameter value, and no longer stops matching a valid
+  ``charset`` because of what follows it or of a quoted-string parameter
+  value that itself contains ``charset`` (#291, #293).
+
+- :func:`~w3lib.encoding.html_body_declared_encoding` now skips HTML
+  comments, like :func:`~w3lib.html.get_base_url` and
+  :func:`~w3lib.html.get_meta_refresh` already did (#305), and falls back to
+  a more lenient scan that finds a ``charset`` attribute regardless of the
+  order or spelling of the other attributes in the tag (#299).
+
+- :func:`~w3lib.encoding.html_to_unicode` now decodes a lead ``0x80`` byte as
+  the euro sign when the encoding is GB18030, matching the WHATWG Encoding
+  Standard (#300).
+
 2.4.1 (2026-03-20)
 ------------------
 


### PR DESCRIPTION
~~Not 100% sure about 2.5.0 instead of 2.4.2, but given the extend of the performance improvements, I think maybe a minor bump is justified.~~

Post-release to-do:
- [ ] Mark the following PRs as ready for review, and close and reopen it to trigger a CI run:
  - [ ] https://github.com/scrapy/scrapy/pull/8178
  - [ ] https://github.com/scrapy/scrapy/pull/8189