### PR TITLE
Avoid quadratic backtracking in get_base_url (fixes #263)

### DIFF
--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -363,11 +363,6 @@ class TestGetBaseUrl:
         )
 
     def test_get_base_url_no_catastrophic_backtracking(self):
-        # Regression test for https://github.com/scrapy/w3lib/issues/263:
-        # many "<base " starts with no closing ">" made _baseurl_re backtrack
-        # quadratically (tens of seconds for tens of thousands of starts). The
-        # time bound is deliberately generous: the fixed code runs in well under
-        # a millisecond, so a quadratic regression would blow past 2 seconds.
         prefix = "<base " * 30000
         start = time.perf_counter()
         assert get_base_url(prefix, "http://example.com/") == "http://example.com/"

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -1,3 +1,5 @@
+import time
+
 from w3lib.html import (
     get_base_url,
     get_meta_refresh,
@@ -360,11 +362,14 @@ class TestGetBaseUrl:
             == "http://example.org/something"
         )
 
-    def test_get_base_url_redos(self):
+    def test_get_base_url_no_catastrophic_backtracking(self):
         # Regression test for https://github.com/scrapy/w3lib/issues/263:
         # many "<base " starts with no closing ">" made _baseurl_re backtrack
-        # quadratically. Extraction must stay fast and still find a real tag.
-        prefix = "<base " * 50000
+        # quadratically (tens of seconds for tens of thousands of starts). The
+        # time bound is deliberately generous: the fixed code runs in well under
+        # a millisecond, so a quadratic regression would blow past 2 seconds.
+        prefix = "<base " * 30000
+        start = time.perf_counter()
         assert get_base_url(prefix, "http://example.com/") == "http://example.com/"
         assert (
             get_base_url(
@@ -373,6 +378,7 @@ class TestGetBaseUrl:
             )
             == "http://example.org/found/"
         )
+        assert time.perf_counter() - start < 2
 
     def test_base_url_in_comment(self):
         assert get_base_url("""<!-- <base href="http://example.com/"/> -->""") == ""

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -360,6 +360,20 @@ class TestGetBaseUrl:
             == "http://example.org/something"
         )
 
+    def test_get_base_url_redos(self):
+        # Regression test for https://github.com/scrapy/w3lib/issues/263:
+        # many "<base " starts with no closing ">" made _baseurl_re backtrack
+        # quadratically. Extraction must stay fast and still find a real tag.
+        prefix = "<base " * 50000
+        assert get_base_url(prefix, "http://example.com/") == "http://example.com/"
+        assert (
+            get_base_url(
+                prefix + '<base href="http://example.org/found/">',
+                "http://example.com/",
+            )
+            == "http://example.org/found/"
+        )
+
     def test_base_url_in_comment(self):
         assert get_base_url("""<!-- <base href="http://example.com/"/> -->""") == ""
         assert get_base_url("""<!-- <base href="http://example.com/"/>""") == ""

--- a/w3lib/html.py
+++ b/w3lib/html.py
@@ -23,7 +23,7 @@ _ent_re = re.compile(
 )
 _tag_re = re.compile(r"<[a-zA-Z\/!].*?>", re.DOTALL)
 _baseurl_re = re.compile(
-    r"<base\s[^>]*href\s*=\s*[\"\']\s*([^\"\'\s]+)\s*[\"\']", re.IGNORECASE
+    r"<base\s[^<>]*href\s*=\s*[\"\']\s*([^\"\'\s]+)\s*[\"\']", re.IGNORECASE
 )
 _meta_refresh_re = re.compile(
     r'<meta\s[^>]*http-equiv[^>]*refresh[^>]*content\s*=\s*(?P<quote>["\'])(?P<int>(\d*\.)?\d+)\s*;\s*url=\s*(?P<url>.*?)(?P=quote)',


### PR DESCRIPTION
Fixes #263.

## Problem
`w3lib.html._baseurl_re` is `<base\s[^>]*href\s*=...`. The `[^>]*` matches everything up to the next `>`. On input with many `<base ` starts and no closing `>` (for example `<base ` repeated tens of thousands of times), the regex backtracks quadratically, so `get_base_url()` takes several seconds:

    n= 5000   0.36s
    n=10000   1.44s   (4x for 2x input -> O(n^2))
    n=20000   5.91s

(Scrapy itself only passes the first 4 KB to this function, so it is not affected there, but other callers can be.)

## Fix
Use `[^<>]` instead of `[^>]`. An HTML tag's content cannot contain a raw `<`, so this still matches every valid `<base ...>` tag, but stops the `*` from scanning across tag boundaries. The match becomes linear:

    n=10000   0.001s
    n=20000   0.001s
    n=40000   0.001s

## Tests
Added `TestGetBaseUrl.test_get_base_url_redos`, checking both that the pathological input is handled (returning the fallback base URL) and that a real `<base href>` after such a prefix is still found. Full suite passes (355 passed); `ruff check` / `ruff format` are clean.

Note: `get_meta_refresh()` shows similar quadratic behavior on analogous input, but via a different code path (not `_baseurl_re`). I kept this PR focused on #263 and am happy to look into that separately.