### PR TITLE
Avoid quadratic backtracking in get_meta_refresh (fixes #265)

### DIFF
--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -466,11 +466,6 @@ class TestGetMetaRefresh:
         assert get_meta_refresh(body, baseurl) == (5, "http://example.org/newpage")
 
     def test_get_meta_refresh_no_catastrophic_backtracking(self):
-        # Regression test for https://github.com/scrapy/w3lib/issues/265:
-        # many "<meta " starts with no closing ">" made _meta_tag_re backtrack
-        # quadratically (same class of bug as #263 for _baseurl_re). The time
-        # bound is deliberately generous; the fixed code runs in well under a
-        # millisecond, so a quadratic regression would blow past 2 seconds.
         prefix = "<meta " * 30000
         start = time.perf_counter()
         assert get_meta_refresh(prefix) == (None, None)

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -466,7 +466,7 @@ class TestGetMetaRefresh:
         assert get_meta_refresh(body, baseurl) == (5, "http://example.org/newpage")
 
     def test_get_meta_refresh_no_catastrophic_backtracking(self):
-        prefix = "<meta " * 30000
+        prefix = "<meta " * 80000
         start = time.perf_counter()
         assert get_meta_refresh(prefix) == (None, None)
         assert get_meta_refresh(

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -1,3 +1,5 @@
+import time
+
 from w3lib.html import (
     get_base_url,
     get_meta_refresh,
@@ -462,6 +464,21 @@ class TestGetMetaRefresh:
             <body>blahablsdfsal&amp;</body>
             </html>"""
         assert get_meta_refresh(body, baseurl) == (5, "http://example.org/newpage")
+
+    def test_get_meta_refresh_no_catastrophic_backtracking(self):
+        # Regression test for https://github.com/scrapy/w3lib/issues/265:
+        # many "<meta " starts with no closing ">" made _meta_tag_re backtrack
+        # quadratically (same class of bug as #263 for _baseurl_re). The time
+        # bound is deliberately generous; the fixed code runs in well under a
+        # millisecond, so a quadratic regression would blow past 2 seconds.
+        prefix = "<meta " * 30000
+        start = time.perf_counter()
+        assert get_meta_refresh(prefix) == (None, None)
+        assert get_meta_refresh(
+            prefix
+            + '<meta http-equiv="refresh" content="3; url=http://example.org/next/">'
+        ) == (3.0, "http://example.org/next/")
+        assert time.perf_counter() - start < 2
 
     def test_without_url(self):
         # refresh without url should return (None, None)

--- a/w3lib/html.py
+++ b/w3lib/html.py
@@ -38,7 +38,7 @@ _cdata_re = re.compile(
     r"((?P<cdata_s><!\[CDATA\[)(?P<cdata_d>.*?)(?P<cdata_e>\]\]>))", re.DOTALL
 )
 _tags_re = re.compile("</?([^ >/]+).*?>", re.DOTALL | re.IGNORECASE)
-_meta_tag_re = re.compile(r"<meta\b[^>]*>", re.IGNORECASE)
+_meta_tag_re = re.compile(r"<meta\b[^<>]*>", re.IGNORECASE)
 
 
 HTML5_WHITESPACE = " \t\n\r\x0c"


### PR DESCRIPTION
Fixes #265.

## Problem
`get_meta_refresh()` is quadratic on malformed input, the same class of bug as #263 (`get_base_url`). The cause is `_meta_tag_re`:

    _meta_tag_re = re.compile(r"<meta\b[^>]*>", re.IGNORECASE)

On input with many `<meta ` starts and no closing `>` (e.g. `"<meta " * n`), `[^>]*` backtracks quadratically:

    n= 5000   0.07s
    n=10000   0.27s   (~4x for 2x input -> O(n^2))
    n=20000   1.53s

## Fix
Use `[^<>]` instead of `[^>]`, exactly as in #263. An HTML tag's content cannot contain a raw `<`, so valid `<meta>` tags still match, while the `*` can no longer scan across tag boundaries. `get_meta_refresh` becomes linear (sub-millisecond at the sizes above).

## Tests
Added `TestGetMetaRefresh.test_get_meta_refresh_no_catastrophic_backtracking` with a generous time bound (so a quadratic regression fails the test) that also checks a real refresh `<meta>` after the pathological prefix is still parsed. Full suite passes (355 passed); `ruff check` / `ruff format` are clean.