### PR TITLE
Avoid quadratic backtracking in replace_tags and remove_tags

### DIFF
--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -121,6 +121,17 @@ class TestReplaceTags:
             == "Click here"
         )
 
+    def test_replace_tags_no_catastrophic_backtracking(self):
+        # Regression test: `_tag_re` previously used `.*?`, which backtracks
+        # quadratically on many "<a" starts with no ">" (same class as the
+        # ReDoS fixes in get_base_url / get_meta_refresh). The time bound is
+        # generous; the fixed code runs in well under a millisecond.
+        evil = "<a" * 50000
+        start = time.perf_counter()
+        assert replace_tags(evil) == evil  # incomplete tags (no ">") are untouched
+        assert replace_tags(evil + "<b>x</b>") == evil + "x"
+        assert time.perf_counter() - start < 2
+
 
 class TestRemoveComments:
     def test_returns_unicode(self):
@@ -213,6 +224,16 @@ class TestRemoveTags:
             )
             == ""
         )
+
+    def test_remove_tags_no_catastrophic_backtracking(self):
+        # Regression test: `_tags_re` previously used `.*?` with a `([^ >/]+)`
+        # group that did not exclude "<", backtracking quadratically on many
+        # "<a" starts with no ">". Must stay fast and still strip real tags.
+        evil = "<a" * 30000
+        start = time.perf_counter()
+        assert remove_tags(evil) == evil
+        assert remove_tags(evil + "<b>x</b>") == evil + "x"
+        assert time.perf_counter() - start < 2
 
 
 class TestRemoveTagsWithContent:

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -122,10 +122,6 @@ class TestReplaceTags:
         )
 
     def test_replace_tags_no_catastrophic_backtracking(self):
-        # Regression test: `_tag_re` previously used `.*?`, which backtracks
-        # quadratically on many "<a" starts with no ">" (same class as the
-        # ReDoS fixes in get_base_url / get_meta_refresh). The time bound is
-        # generous; the fixed code runs in well under a millisecond.
         evil = "<a" * 50000
         start = time.perf_counter()
         assert replace_tags(evil) == evil  # incomplete tags (no ">") are untouched
@@ -226,9 +222,6 @@ class TestRemoveTags:
         )
 
     def test_remove_tags_no_catastrophic_backtracking(self):
-        # Regression test: `_tags_re` previously used `.*?` with a `([^ >/]+)`
-        # group that did not exclude "<", backtracking quadratically on many
-        # "<a" starts with no ">". Must stay fast and still strip real tags.
         evil = "<a" * 30000
         start = time.perf_counter()
         assert remove_tags(evil) == evil

--- a/w3lib/html.py
+++ b/w3lib/html.py
@@ -21,7 +21,7 @@ _ent_re = re.compile(
     r"&((?P<named>[a-z\d]+)|#(?P<dec>\d+)|#x(?P<hex>[a-f\d]+))(?P<semicolon>;?)",
     re.IGNORECASE,
 )
-_tag_re = re.compile(r"<[a-zA-Z\/!].*?>", re.DOTALL)
+_tag_re = re.compile(r"<[a-zA-Z\/!][^<>]*>", re.DOTALL)
 _baseurl_re = re.compile(
     r"<base\s[^<>]*href\s*=\s*[\"\']\s*([^\"\'\s]+)\s*[\"\']", re.IGNORECASE
 )
@@ -37,7 +37,7 @@ _meta_refresh_re2 = re.compile(
 _cdata_re = re.compile(
     r"((?P<cdata_s><!\[CDATA\[)(?P<cdata_d>.*?)(?P<cdata_e>\]\]>))", re.DOTALL
 )
-_tags_re = re.compile("</?([^ >/]+).*?>", re.DOTALL | re.IGNORECASE)
+_tags_re = re.compile("</?([^ <>/]+)[^<>]*>", re.DOTALL | re.IGNORECASE)
 _meta_tag_re = re.compile(r"<meta\b[^<>]*>", re.IGNORECASE)
 
 

--- a/w3lib/html.py
+++ b/w3lib/html.py
@@ -21,7 +21,7 @@ _ent_re = re.compile(
     r"&((?P<named>[a-z\d]+)|#(?P<dec>\d+)|#x(?P<hex>[a-f\d]+))(?P<semicolon>;?)",
     re.IGNORECASE,
 )
-_tag_re = re.compile(r"<[a-zA-Z\/!][^<>]*>", re.DOTALL)
+_tag_re = re.compile(r"<[a-zA-Z\/!][^<>]*>")
 _baseurl_re = re.compile(
     r"<base\s[^<>]*href\s*=\s*[\"\']\s*([^\"\'\s]+)\s*[\"\']", re.IGNORECASE
 )
@@ -37,7 +37,7 @@ _meta_refresh_re2 = re.compile(
 _cdata_re = re.compile(
     r"((?P<cdata_s><!\[CDATA\[)(?P<cdata_d>.*?)(?P<cdata_e>\]\]>))", re.DOTALL
 )
-_tags_re = re.compile("</?([^ <>/]+)[^<>]*>", re.DOTALL | re.IGNORECASE)
+_tags_re = re.compile("</?([^ <>/]+)[^<>]*>", re.IGNORECASE)
 _meta_tag_re = re.compile(r"<meta\b[^<>]*>", re.IGNORECASE)
 
 


### PR DESCRIPTION
Follows #263 / #264 and #265 / #266. Two more regexes in `w3lib.html` backtrack quadratically on input with many `<` starts and no `>`:

## `replace_tags` (`_tag_re`)

    _tag_re = re.compile(r"<[a-zA-Z\/!].*?>", re.DOTALL)

Timing `replace_tags("<a" * n)`: n=2000 -> 0.04s, n=4000 -> 0.16s, n=8000 -> 0.63s  (O(n^2)).

## `remove_tags` (`_tags_re`)

    _tags_re = re.compile("</?([^ >/]+).*?>", ...)

`remove_tags("<a" * 20000)` takes ~20s.

Same root cause as #263 / #265: an unbounded `.*?` scans across tag boundaries. For `_tags_re`, the `([^ >/]+)` tag-name group additionally does not exclude `<`, so it over-consumes on its own.

## Fix
- `_tag_re`: `.*?` -> `[^<>]*`.
- `_tags_re`: `.*?` -> `[^<>]*`, and `([^ >/]+)` -> `([^ <>/]+)`.

A tag cannot contain a raw `<`, so valid tags still match; both functions become linear (sub-millisecond on the inputs above). Added regression tests; full suite passes (358 passed); `ruff check` / `ruff format` clean.

Note: `_cdata_re` (used in `unquote_markup`) shows a similar blow-up on many `<![CDATA[` with no `]]>`, but CDATA content can legitimately contain `<` and `>`, so it needs a different approach — happy to handle that in a separate PR if you'd like.