### PR TITLE
fix: preserve semicolon-separated query parameters in add_or_replace_parameter()

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -1015,11 +1015,22 @@ class TestUrl:
             == "http://domain/test?arg1=v3&arg2=v2"
         )
 
-    @pytest.mark.xfail(reason="https://github.com/scrapy/w3lib/issues/164")
-    def test_add_or_replace_parameter_fail(self):
+    def test_add_or_replace_parameter_semicolon_separator(self):
+        # Semicolons are a valid historic query-param separator (issue #164).
+        # Parameters must be preserved, not silently dropped.
         assert (
             add_or_replace_parameter("http://domain/test?arg1=v1;arg2=v2", "arg1", "v3")
             == "http://domain/test?arg1=v3&arg2=v2"
+        )
+        # Replacing the second parameter also works
+        assert (
+            add_or_replace_parameter("http://domain/test?arg1=v1;arg2=v2", "arg2", "v3")
+            == "http://domain/test?arg1=v1&arg2=v3"
+        )
+        # Mixed separators
+        assert (
+            add_or_replace_parameter("http://domain/test?a=1;b=2&c=3", "b", "99")
+            == "http://domain/test?a=1&b=99&c=3"
         )
 
     def test_add_or_replace_parameters(self):

--- a/w3lib/url.py
+++ b/w3lib/url.py
@@ -382,7 +382,13 @@ def url_query_cleaner(
 def _add_or_replace_parameters(url: str, params: dict[bytes, bytes]) -> str:
     parsed = _urlsplit(url)
 
-    current_args = _parse_qsl(parsed.query, keep_blank_values=True)
+    # Normalize semicolon separators to ampersands (issue #164).
+    # Semicolons are a historic but valid query-param separator used by many
+    # CGI/PHP/legacy applications. We normalise here so that all params are
+    # preserved; the output always uses the canonical "&" separator.
+    normalized_query = parsed.query.replace(";", "&")
+    current_args = _parse_qsl(normalized_query, keep_blank_values=True)
+
 
     new_args: list[tuple[bytes, bytes]] = []
     seen_params: set[bytes] = set()


### PR DESCRIPTION
Fixes #164.

add_or_replace_parameter() and add_or_replace_parameters() incorrectly dropped existing query parameters when the input URL used semicolons (;) as query parameter separators.

Problem

The internal query parser only split query strings on &. As a result, URLs such as:

http://domain/test?arg1=v1;arg2=v2

were interpreted as a single parameter instead of two separate parameters.

For example:

add_or_replace_parameter(
    "http://domain/test?arg1=v1;arg2=v2",
    "arg1",
    "v3",
)

# Before
# http://domain/test?arg1=v3
# arg2 is silently lost

This causes existing query parameters to be unintentionally discarded when replacing or adding parameters.

Solution

Update the internal query parsing logic to recognize both & and ; as valid query parameter separators. The resulting URL is normalized to use &, while preserving all existing query parameters.

# After
add_or_replace_parameter(
    "http://domain/test?arg1=v1;arg2=v2",
    "arg1",
    "v3",
)

# http://domain/test?arg1=v3&arg2=v2
Testing

The existing regression test for Issue #164 now passes, verifying that semicolon-separated query strings are handled correctly and that existing parameters are preserved.