### PR TITLE
Fix canonicalize_url IDNA-encoding the port and userinfo of a non-ASCII host

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -1472,6 +1472,23 @@ class TestCanonicalizeUrl:
             == "http://xn--p8j9a0d9c9a.xn--q9jyb4c/?maxResults=5&query=%E3%82%B5"
         )
 
+    def test_canonicalize_idns_with_port(self):
+        # https://github.com/scrapy/w3lib/issues/222
+        # IDNA encoding must apply to the host only, not the port.
+        assert (
+            canonicalize_url("https://тест.тест:33")
+            == "https://xn--e1aybc.xn--e1aybc:33/"
+        )
+        # ... and not to the userinfo either (which stays case-sensitive).
+        assert (
+            canonicalize_url("sftp://UsEr:PaSs@тест.тест:33/")
+            == "sftp://UsEr:PaSs@xn--e1aybc.xn--e1aybc:33/"
+        )
+        # An IDNA host without a port is still encoded correctly.
+        assert (
+            canonicalize_url("https://тест.тест/") == "https://xn--e1aybc.xn--e1aybc/"
+        )
+
     def test_quoted_slash_and_question_sign(self):
         assert (
             canonicalize_url("http://foo.com/AC%2FDC+rocks%3f/?yeah=1")

--- a/w3lib/url.py
+++ b/w3lib/url.py
@@ -575,13 +575,33 @@ __all__ = [
 ]
 
 
+def _idna_netloc(netloc: str) -> str:
+    """Apply IDNA encoding to the host part of ``netloc`` only.
+
+    ``_idna_str`` must not be applied to the whole netloc: it would mangle the
+    userinfo and the port of a non-ASCII host. For example the ``:33`` in
+    ``тест.тест:33`` would be folded into the last IDNA label, producing
+    ``xn--:33-qdd4dec`` instead of ``xn--e1aybc.xn--e1aybc:33``.
+    See https://github.com/scrapy/w3lib/issues/222.
+    """
+    userinfo, at, hostport = netloc.rpartition("@")
+    if hostport.startswith("["):
+        # IPv6 literals are ASCII, so IDNA is a no-op; leave the bracketed host
+        # (and any port) untouched.
+        return netloc
+    host, colon, port = hostport.rpartition(":")
+    if not colon:
+        host, port = hostport, ""
+    return userinfo + at + _idna_str(host) + colon + port
+
+
 def _safe_ParseResult(
     parts: ParseResult, encoding: str = "utf8", path_encoding: str = "utf8"
 ) -> tuple[str, str, str, str, str, str]:
     # IDNA encoding can fail for too long labels (>63 characters)
     # or missing labels (e.g. http://.example.com)
     try:
-        netloc = _idna_str(parts.netloc)
+        netloc = _idna_netloc(parts.netloc)
     except UnicodeError:
         netloc = parts.netloc
 


### PR DESCRIPTION
Fixes #222.

## Problem
`canonicalize_url` runs IDNA encoding on the entire netloc, so when a non-ASCII host has a port (or userinfo), those parts get folded into the last IDNA label and mangled:

```pycon
>>> canonicalize_url('https://тест.тест:33')
'https://xn--e1aybc.xn--:33-qdd4dec/'   # the :33 is corrupted
```

Expected:

```
'https://xn--e1aybc.xn--e1aybc:33/'
```

`safe_url_string` already handles host and port separately; only the `canonicalize_url` path (via `_safe_ParseResult`) was affected.

## Fix
Add `_idna_netloc`, which applies IDNA to the host substring only and leaves any `userinfo@` prefix and `:port` suffix verbatim. IPv6 literals are ASCII (IDNA is a no-op) so the bracketed host is returned untouched. Because IDNA is a no-op on ASCII, no existing ASCII-netloc behaviour changes. The existing `UnicodeError` fallback (too-long / missing labels) is preserved.

## Tests
Added `test_canonicalize_idns_with_port` covering host+port, userinfo+port (userinfo stays case-sensitive), and the no-port case. Proven to fail on unpatched source (`xn--33-mlc2cdc`) and pass with the fix. Full suite: 359 passed, 0 failures; mypy + ruff clean.

Note: the trailing-multiple-dots addendum in #222 is left out of scope, as the reporter noted it may be standards-correct behaviour.