### PR TITLE
avoid quadratic backtracking in remove_tags_with_content

### DIFF
--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -277,6 +277,18 @@ class TestRemoveTagsWithContent:
             == "<span></span>"
         )
 
+    def test_no_catastrophic_backtracking(self):
+        evil = "<script " * 50000
+        start = time.perf_counter()
+        assert remove_tags_with_content(evil, which_ones=("script",)) == evil
+        assert (
+            remove_tags_with_content(
+                evil + "<script>x</script>", which_ones=("script",)
+            )
+            == evil
+        )
+        assert time.perf_counter() - start < 2
+
 
 class TestReplaceEscapeChars:
     def test_returns_unicode(self):

--- a/w3lib/html.py
+++ b/w3lib/html.py
@@ -231,9 +231,9 @@ def remove_tags(
 def _build_remove_tags_pattern(tags_tuple: tuple[str, ...]) -> re.Pattern[str]:
     tags = "|".join(re.escape(tag) for tag in tags_tuple)
     pattern = rf"""
-        <(?P<tag>{tags})\b[^>]*>.*?</(?P=tag)>
+        <(?P<tag>{tags})\b[^<>]*>.*?</(?P=tag)>
         |
-        <(?P<tag2>{tags})\b[^>]*/>
+        <(?P<tag2>{tags})\b[^<>]*/>
     """
     return re.compile(pattern, re.IGNORECASE | re.DOTALL | re.VERBOSE)
 


### PR DESCRIPTION
`remove_tags_with_content("<script " * n, which_ones=("script",))`:

    n=10000    0.56s
    n=20000    2.05s
    n=40000   10.68s

`_build_remove_tags_pattern` matches a tag's attribute span with `<(tag)\b[^>]*>`. On input with many `<script ` starts and no closing `>`, the `[^>]*` backtracks quadratically. Same case as #263 (`_baseurl_re`) and #265 (`_meta_tag_re`): a tag cannot contain a raw `<`, so `[^<>]` still matches valid tags while stopping the scan from crossing tag boundaries, making it linear.

`get_meta_refresh` reaches the same path, since it strips `script`/`noscript` via `remove_tags_with_content` by default.