### PR TITLE
fix _urlsplit early-exit dropping the fragment delimiter

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -1432,6 +1432,15 @@ class TestCanonicalizeUrl:
             == "http://user:pass@www.example.com/do?a=1#frag"
         )
 
+    def test_remove_fragments_ipv6_host(self):
+        # The fragment delimiter must still be detected when the netloc is a
+        # bracketed IPv6 literal and the URL also has a query string.
+        assert canonicalize_url("http://[::1]/do?a=1#frag") == "http://[::1]/do?a=1"
+        assert (
+            canonicalize_url("http://[::1]/do?a=1#frag", keep_fragments=True)
+            == "http://[::1]/do?a=1#frag"
+        )
+
     def test_dont_convert_safe_characters(self):
         # dont convert safe characters to percent encoding representation
         assert (

--- a/w3lib/_url.py
+++ b/w3lib/_url.py
@@ -658,7 +658,13 @@ def _urlsplit(  # pylint: disable=too-many-locals,too-many-statements
             open_br_pos = idx
         elif char == "]" and closing_br_pos == -1:
             closing_br_pos = idx
-        if slash_pos != question_pos != hash_pos != open_br_pos != closing_br_pos != -1:
+        if -1 not in (
+            slash_pos,
+            question_pos,
+            hash_pos,
+            open_br_pos,
+            closing_br_pos,
+        ):
             break
 
     if url[:2] == "//":


### PR DESCRIPTION
`_urlsplit` scans the URL once for `/ ? # [ ]` and breaks out as soon as it believes all five have been located. The exit test is a chained comparison:

    if slash_pos != question_pos != hash_pos != open_br_pos != closing_br_pos != -1:

which evaluates as `slash_pos != question_pos and question_pos != hash_pos and ...`, not "every position found". With a bracketed IPv6 netloc plus a query the chain becomes true at the `?`, before the `#` is seen:

    >>> from urllib.parse import urlsplit
    >>> urlsplit('http://[::1]/p?a=1#frag').fragment
    'frag'
    >>> from w3lib._url import _urlsplit
    >>> _urlsplit('http://[::1]/p?a=1#frag').fragment
    ''

So `hash_pos` stays `-1` and the fragment is folded into the query. This surfaces in the public API:

    >>> canonicalize_url('http://[::1]/p?a=1#frag')   # fragment should be dropped
    'http://[::1]/p?a=1%23frag'

Replacing the condition with a real all-found check makes the early exit match a full scan. Verified equal to a no-break full scan over 3M randomized inputs, and the existing suite still passes.