### PR TITLE
start _urlsplit delimiter scan at 0 for authority-less URLs

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -915,6 +915,8 @@ class TestUrl:
         assert url_query_parameter("product.html?id=", "id", keep_blank_values=1) == ""
         # only the first one is returned
         assert url_query_parameter("product.html?id=200&id=201&id=202", "id") == "200"
+        # query delimiter at index 1 of a short relative URL
+        assert url_query_parameter("a?id=200", "id") == "200"
 
     @pytest.mark.xfail
     def test_url_query_parameter_2(self):
@@ -1440,6 +1442,14 @@ class TestCanonicalizeUrl:
             canonicalize_url("http://[::1]/do?a=1#frag", keep_fragments=True)
             == "http://[::1]/do?a=1#frag"
         )
+
+    def test_remove_fragments_relative_url(self):
+        # The fragment/query delimiter must be detected even when it sits at
+        # index 0 or 1 of a relative URL (no authority to skip over).
+        assert canonicalize_url("a#frag") == "a"
+        assert canonicalize_url("a#frag", keep_fragments=True) == "a#frag"
+        assert canonicalize_url("a?b=1#frag") == "a?b=1"
+        assert canonicalize_url("?b=1") == "/?b=1"
 
     def test_dont_convert_safe_characters(self):
         # dont convert safe characters to percent encoding representation

--- a/w3lib/_url.py
+++ b/w3lib/_url.py
@@ -646,8 +646,12 @@ def _urlsplit(  # pylint: disable=too-many-locals,too-many-statements
         scheme = m.group(1).lower()
         url = url[m.end() :]
 
+    # The scan skips the leading "//" of an authority; for URLs without an
+    # authority it must start at 0, otherwise a "?" or "#" at index 0 or 1
+    # (e.g. relative URLs like "a?b" or "a#f") is never recorded.
+    scan_start = 2 if url[:2] == "//" else 0
     slash_pos = question_pos = hash_pos = open_br_pos = closing_br_pos = -1
-    for idx, char in enumerate(url[2:], 2):
+    for idx, char in enumerate(url[scan_start:], scan_start):
         if char == "/" and slash_pos == -1:
             slash_pos = idx
         elif char == "?" and question_pos == -1:


### PR DESCRIPTION
`_urlsplit` scans for delimiters with `enumerate(url[2:], 2)`. That offset skips the leading `//` of an authority, but it also runs when there is no authority, so a delimiter at index 0 or 1 is never recorded:

    >>> from urllib.parse import urlsplit
    >>> urlsplit("a?b")
    SplitResult(scheme='', netloc='', path='a', query='b', fragment='')
    >>> from w3lib._url import _urlsplit
    >>> tuple(_urlsplit("a?b"))
    ('', '', 'a?b', '', '')          # query merged into path

For short relative URLs (`a?b`, `?x=1`, `a#f`) the `?`/`#` stays in the path. Surfaces through the public helpers:

    url_query_parameter("a?id=1", "id")   -> None   (should be "1")
    canonicalize_url("a#frag")             -> "a%23frag"  (fragment not stripped)

#272 fixed the early-exit for the IPv6 case but the scan still starts at index 2, so this is a separate path. Start the scan at 0 unless the URL begins with `//`, in which case the existing offset still skips the authority prefix.