### PR TITLE
Only IDNA-encode the host in canonicalize_url, not the whole netloc

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,13 @@
 w3lib release notes
 ===================
 
+Unreleased
+----------
+
+- :func:`~w3lib.url.canonicalize_url` no longer corrupts an
+  internationalized host when a port or userinfo is present; only the host
+  is IDNA-encoded (#275).
+
 2.4.1 (2026-03-20)
 ------------------
 

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -1491,6 +1491,18 @@ class TestCanonicalizeUrl:
             == "http://xn--p8j9a0d9c9a.xn--q9jyb4c/?maxResults=5&query=%E3%82%B5"
         )
 
+    def test_canonicalize_idns_with_port(self):
+        # A port (or userinfo) must not be IDNA-encoded together with the host
+        # (gh-222); only the host is encoded.
+        assert (
+            canonicalize_url("https://тест.тест:33")
+            == "https://xn--e1aybc.xn--e1aybc:33/"
+        )
+        assert (
+            canonicalize_url("http://u:p@тест.тест:33/x")
+            == "http://u:p@xn--e1aybc.xn--e1aybc:33/x"
+        )
+
     def test_quoted_slash_and_question_sign(self):
         assert (
             canonicalize_url("http://foo.com/AC%2FDC+rocks%3f/?yeah=1")

--- a/w3lib/url.py
+++ b/w3lib/url.py
@@ -26,7 +26,6 @@ from ._url import (
     RFC3986_UNRESERVED as RFC3986_UNRESERVED,
     RFC3986_USERINFO_SAFE_CHARS as RFC3986_USERINFO_SAFE_CHARS,
     _idna_bytes,
-    _idna_str,
     _parse_qs,
     _parse_qsl,
     _quote,
@@ -578,12 +577,40 @@ __all__ = [
 def _safe_ParseResult(
     parts: ParseResult, encoding: str = "utf8", path_encoding: str = "utf8"
 ) -> tuple[str, str, str, str, str, str]:
-    # IDNA encoding can fail for too long labels (>63 characters)
-    # or missing labels (e.g. http://.example.com)
-    try:
-        netloc = _idna_str(parts.netloc)
-    except UnicodeError:
-        netloc = parts.netloc
+    # Only the host may be IDNA-encoded. Encoding the whole netloc corrupts
+    # any userinfo or port, because the "idna" codec would treat e.g.
+    # "тест:33" as a single domain label (see gh-222). Rebuild the netloc from
+    # its parts, IDNA-encoding just the host, mirroring safe_url_string().
+    netloc_buf = bytearray()
+
+    if parts.username is not None or parts.password is not None:
+        if parts.username is not None:
+            netloc_buf += parts.username.encode(encoding)
+        if parts.password is not None:
+            netloc_buf.append(58)  # ord(":")
+            netloc_buf += parts.password.encode(encoding)
+        netloc_buf.append(64)  # ord("@")
+
+    if parts.hostname is not None:
+        if ":" in parts.hostname:
+            # IPv6 address: urlsplit() strips the brackets from the hostname,
+            # but they are required in the netloc when rebuilding the URL.
+            netloc_buf.append(91)  # ord("[")
+            netloc_buf += parts.hostname.encode("ascii")
+            netloc_buf.append(93)  # ord("]")
+        else:
+            # IDNA encoding can fail for too long labels (>63 characters)
+            # or missing labels (e.g. http://.example.com)
+            try:
+                netloc_buf += _idna_bytes(parts.hostname)
+            except UnicodeError:
+                netloc_buf += parts.hostname.encode(encoding)
+
+    if parts.port is not None:
+        netloc_buf.append(58)  # ord(":")
+        netloc_buf += str(parts.port).encode(encoding)
+
+    netloc = netloc_buf.decode()
 
     tmp_buf = bytearray()
 


### PR DESCRIPTION
## Summary

Fixes #222.

`canonicalize_url()` corrupts internationalized hostnames whenever a port (or userinfo) is present:

```python
>>> from w3lib.url import canonicalize_url
>>> canonicalize_url("https://тест.тест:33")
'https://xn--e1aybc.xn--33-mlc2cdc/'   # before  (port folded into the last label)
'https://xn--e1aybc.xn--e1aybc:33/'    # after   (expected)
```

## Root cause

`_safe_ParseResult()` did `netloc = _idna_str(parts.netloc)`, passing the **entire** netloc to the `"idna"` codec. That codec expects a bare domain name and splits on `.`, so for `тест.тест:33` it treats `тест:33` as one label and punycode-encodes the port into it.

## Fix

Rebuild the netloc from its parsed parts and IDNA-encode **only the host**, keeping any userinfo and port verbatim and preserving IPv6 brackets. This mirrors what `safe_url_string()` already does for the same purpose, so the two entry points now handle IDNA hosts consistently. `_idna_str` is no longer used and its import is removed.

## Tests

Added `test_canonicalize_idns_with_port` (IDN host with a port, and with userinfo + port). Full `tests/test_url.py` and the whole suite pass (361 passed, 76 xfailed unchanged), and existing IDNA / port / userinfo / IPv6 cases are unaffected.