### PR TITLE
reject data-prefixed schemes in parse_data_uri

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -1714,6 +1714,11 @@ class TestDataURI:
         with pytest.raises(ValueError, match="not a data URI"):
             parse_data_uri("http://example.com/")
 
+    def test_data_prefixed_scheme(self):
+        for uri in ("datax:,A%20brief%20note", "database:,A%20brief%20note"):
+            with pytest.raises(ValueError, match="not a data URI"):
+                parse_data_uri(uri)
+
     def test_scheme_case_insensitive(self):
         result = parse_data_uri("DATA:,A%20brief%20note")
         assert result.data == b"A brief note"

--- a/w3lib/url.py
+++ b/w3lib/url.py
@@ -521,7 +521,7 @@ def parse_data_uri(uri: str | bytes) -> ParseDataURIResult:
     scheme, _, uri = uri.partition(b":")
     if not scheme or not uri:
         raise ValueError("invalid URI")
-    if scheme[:4].lower() != b"data":
+    if scheme.lower() != b"data":
         raise ValueError("not a data URI")
 
     # RFC 3986 section 2.1 allows percent encoding to escape characters that


### PR DESCRIPTION
    >>> parse_data_uri("datax:,x")
    ParseDataURIResult(media_type='text/plain', media_type_parameters={'charset': 'US-ASCII'}, data=b'x')

The scheme guard is `scheme[:4].lower() != b"data"`, a prefix match, so any
scheme that starts with `data` (`datax:`, `database:`, `data-something:`) slips
past it and parses as a data URI instead of raising "not a data URI". The
scheme is attacker-supplied, so this accepts non-data URIs as data URIs.

Compare the whole scheme. Regression test added for `datax:`/`database:`;
`DATA:`/`DaTa:` still parse.