### PR TITLE
ignore brackets outside the authority in _urlsplit

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -390,6 +390,13 @@ SAFE_URL_URL_CASES = (
     ("https://example\uff20.com", ValueError),
     # changed after NFKC normalisation
     ("https://examplｅ.com", "https://example.com"),
+    # "[" and "]" outside the authority are ordinary characters and must not
+    # be treated as IPv6 host delimiters.
+    ("https://example.com/[x]", "https://example.com/%5Bx%5D"),
+    ("https://example.com/a]b", "https://example.com/a%5Db"),
+    ("http://example.com/search?tags[]=a", "http://example.com/search?tags%5B%5D=a"),
+    ("https://example.com/a#f[1]", "https://example.com/a#f%5B1%5D"),
+    ("http://[::1]:8080/p?q=[1]", "http://[::1]:8080/p?q=%5B1%5D"),
 )
 
 

--- a/w3lib/_url.py
+++ b/w3lib/_url.py
@@ -672,8 +672,6 @@ def _urlsplit(  # pylint: disable=too-many-locals,too-many-statements
             break
 
     if url[:2] == "//":
-        if (open_br_pos != -1) != (closing_br_pos != -1):
-            raise ValueError("Invalid IPv6 URL")
         delim = len(url)
 
         if 0 < slash_pos < delim:
@@ -682,6 +680,17 @@ def _urlsplit(  # pylint: disable=too-many-locals,too-many-statements
             delim = question_pos
         if 0 < hash_pos < delim:
             delim = hash_pos
+
+        # Brackets only delimit an IPv6 host when they fall inside the
+        # authority. A "[" or "]" in the path, query or fragment is an
+        # ordinary character and must not drive IPv6 host parsing.
+        if not 2 <= open_br_pos < delim:
+            open_br_pos = -1
+        if not 2 <= closing_br_pos < delim:
+            closing_br_pos = -1
+
+        if (open_br_pos != -1) != (closing_br_pos != -1):
+            raise ValueError("Invalid IPv6 URL")
 
         netloc = url[2:delim]
         if open_br_pos != -1 and closing_br_pos != -1:


### PR DESCRIPTION
safe_url_string and canonicalize_url raise on ordinary URLs that carry a
"[" or "]" in the path, query or fragment:

    >>> safe_url_string("http://example.com/search?tags[]=a")
    ValueError: 'example.com' does not appear to be an IPv4 or IPv6 address

_urlsplit records the first "[" and "]" from a scan over the whole URL and
uses those positions to gate IPv6 host validation, without checking they sit
inside the authority. A bracket in a later component is then read as an IPv6
host delimiter: it raises, or when the brackets straddle the netloc it
returns an empty hostname. Clamp open_br_pos/closing_br_pos to the netloc
region (2..delim) before the checks so only authority brackets count.

The added cases fail without the patch. A differential against stdlib
urlsplit over random inputs shows the previously-raising URLs now parse and
match it, with real IPv6 hosts unaffected.