### PR TITLE
require a letter-initial scheme in _urlsplit

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -641,6 +641,15 @@ class TestUrl:
         assert isinstance(safeurl, str)
         assert safeurl == "http://www.example.com/%C2%A3?unit=%C2%B5"
 
+    def test_safe_url_string_invalid_scheme(self):
+        # A scheme must start with a letter (RFC 3986); a leading digit or
+        # symbol, or an empty scheme, is not a scheme. In particular an empty
+        # scheme must not promote the rest into a scheme-relative URL, which
+        # would expose an attacker-controlled host.
+        assert safe_url_string("://evil.com/path") == "://evil.com/path"
+        assert safe_url_string("1x://evil.com/path") == "1x://evil.com/path"
+        assert safe_url_string("+x://evil.com/path") == "+x://evil.com/path"
+
     def test_safe_url_string_bytes_input(self):
         safeurl = safe_url_string(b"http://www.example.com/")
         assert isinstance(safeurl, str)

--- a/w3lib/_url.py
+++ b/w3lib/_url.py
@@ -51,7 +51,7 @@ _SCHEME_CHARS = frozenset(scheme_chars)
 _USES_PARAMS = frozenset(uses_params)
 _ASCII_TAB_OR_NEWLINE_TRANSLATION_TABLE = str.maketrans("", "", _ASCII_TAB_OR_NEWLINE)
 _C0_CONTROL_OR_SPACE_RE = re.compile(rf"[{_C0_CONTROL_OR_SPACE}]")
-_SCHEME_RE = re.compile(rf"^([{scheme_chars}]*):")
+_SCHEME_RE = re.compile(rf"^([a-zA-Z][{scheme_chars}]*):")
 
 _IPV_FUTURE_RE = re.compile(r"\Av[a-fA-F0-9]+\..+\Z")
 _NETLOC_DELIMS_RE = re.compile(r"[/?#@:]")


### PR DESCRIPTION
Differential against stdlib urlsplit, structured inputs:

    >>> from urllib.parse import urlsplit
    >>> from w3lib._url import _urlsplit
    >>> urlsplit("://evil.com/path").netloc, _urlsplit("://evil.com/path").netloc
    ('', 'evil.com')
    >>> urlsplit("1x://evil.com").scheme, _urlsplit("1x://evil.com").scheme
    ('', '1x')

`_SCHEME_RE` is `^([scheme_chars]*):`, so it accepts an empty scheme and one starting with a digit or symbol. RFC 3986 has `scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )`, and the `urllib.parse.urlsplit` this reimplements only takes the scheme when `i > 0 and url[0].isascii() and url[0].isalpha()`. The empty-scheme case is the one that bites: `safe_url_string("://evil.com/path")` returns `//evil.com/path`, promoting the string into a scheme-relative host that browsers and stdlib would read as a path.

Anchor the scheme to a leading ASCII letter: `^([a-zA-Z][scheme_chars]*):`. All non-port divergences from stdlib over the structured corpus go away, real schemes are unchanged.