### PR TITLE
strip ascii tab and newlines in canonicalize_url for bytes input

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -1607,6 +1607,11 @@ class TestCanonicalizeUrl:
             == "http://www.example.com/abc/def?x=1"
         )
 
+    def test_parse_url_parse_result(self):
+        # an already parsed url is returned as is
+        parts = parse_url("http://www.example.com/path;params?x=1#frag")
+        assert parse_url(parts) is parts
+
     def test_canonicalize_url_idempotence(self):
         for url, enc in [
             ("http://www.bücher.de/résumé?q=résumé", "utf8"),

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -1518,6 +1518,12 @@ class TestCanonicalizeUrl:
             canonicalize_url("http://はじめよう.みんな/?query=サ&maxResults=5")
             == "http://xn--p8j9a0d9c9a.xn--q9jyb4c/?maxResults=5&query=%E3%82%B5"
         )
+        # non-ASCII domain with an explicit port: IDNA encoding must only
+        # apply to the host, not swallow the port separator
+        assert (
+            canonicalize_url("http://www.bücher.de:8080/?q=bücher")
+            == "http://www.xn--bcher-kva.de:8080/?q=b%C3%BCcher"
+        )
 
     def test_quoted_slash_and_question_sign(self):
         assert (

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -1355,17 +1355,20 @@ class TestCanonicalizeUrl:
             == "http://www.example.com/r%C3%A9sum%C3%A9?country=%D0%A0%D0%BE%D1%81%D1%81%D0%B8%D1%8F"
         )
 
-    def test_canonicalize_url_remove_ascii_tab_and_newlines(self):
+    @pytest.mark.parametrize(
+        "url",
+        [
+            pytest.param("http://exa\tmple.com/a\r\nb?q=a\tb", id="str"),
+            pytest.param(b"http://exa\tmple.com/a\r\nb?q=a\tb", id="bytes"),
+        ],
+    )
+    def test_canonicalize_url_remove_ascii_tab_and_newlines(self, url):
         # ASCII tab and newline are removed from anywhere in the URL, matching
         # safe_url_string() and the WHATWG/urlsplit behavior. This must not
         # depend on whether the input is str or bytes: a tab in the host of a
         # bytes URL was previously left in place, so the canonical form kept a
         # host a browser would connect to differently.
-        for url in (
-            "http://exa\tmple.com/a\r\nb?q=a\tb",
-            b"http://exa\tmple.com/a\r\nb?q=a\tb",
-        ):
-            assert canonicalize_url(url) == "http://example.com/ab?q=ab", repr(url)
+        assert canonicalize_url(url) == "http://example.com/ab?q=ab"
 
     def test_normalize_percent_encoding_in_paths(self):
         assert (

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -1355,6 +1355,18 @@ class TestCanonicalizeUrl:
             == "http://www.example.com/r%C3%A9sum%C3%A9?country=%D0%A0%D0%BE%D1%81%D1%81%D0%B8%D1%8F"
         )
 
+    def test_canonicalize_url_remove_ascii_tab_and_newlines(self):
+        # ASCII tab and newline are removed from anywhere in the URL, matching
+        # safe_url_string() and the WHATWG/urlsplit behavior. This must not
+        # depend on whether the input is str or bytes: a tab in the host of a
+        # bytes URL was previously left in place, so the canonical form kept a
+        # host a browser would connect to differently.
+        for url in (
+            "http://exa\tmple.com/a\r\nb?q=a\tb",
+            b"http://exa\tmple.com/a\r\nb?q=a\tb",
+        ):
+            assert canonicalize_url(url) == "http://example.com/ab?q=ab", repr(url)
+
     def test_normalize_percent_encoding_in_paths(self):
         assert (
             canonicalize_url("http://www.example.com/r%c3%a9sum%c3%a9")

--- a/w3lib/_url.py
+++ b/w3lib/_url.py
@@ -815,10 +815,6 @@ def _idna_bytes(input_string: str) -> bytes:
     return _idna(input_string)[0]
 
 
-def _idna_str(input_string: str) -> str:
-    return _idna(input_string)[1]
-
-
 @functools.lru_cache
 def _nfkc_netloc(netloc: str) -> tuple[str, str]:
     cleaned = netloc.translate(_NETLOC_STRIP_CHARS)

--- a/w3lib/_url.py
+++ b/w3lib/_url.py
@@ -431,6 +431,22 @@ def _urlencode(query: _QueryType) -> bytes:
     return b"&".join(result)
 
 
+def _split_params(scheme: str, url: str) -> tuple[str, str]:
+    """Split the params from the path, as urlib.parse.urlparse does."""
+    if scheme in _USES_PARAMS:
+        semi_idx = url.find(";")
+
+        if semi_idx != -1:
+            slash_idx = url.rfind("/")
+
+            if slash_idx != -1 and slash_idx < semi_idx:
+                semi_idx = url.find(";", slash_idx)
+
+            return url[:semi_idx], url[semi_idx + 1 :]
+
+    return url, ""
+
+
 def _urlparse(
     url: str,
     scheme: str = "",
@@ -441,18 +457,7 @@ def _urlparse(
         return ParseResult(scheme, "", "", "", "", "")
 
     scheme, netloc, url, query, fragment = _urlsplit(url, scheme, allow_fragments)
-    params = ""
-
-    if scheme in _USES_PARAMS:
-        semi_idx = url.find(";")
-
-        if semi_idx != -1:
-            slash_idx = url.rfind("/")
-
-            if slash_idx != -1 and slash_idx < semi_idx:
-                semi_idx = url.find(";", slash_idx)
-
-            url, params = url[:semi_idx], url[semi_idx + 1 :]
+    url, params = _split_params(scheme, url)
 
     return ParseResult(scheme, netloc, url, params, query, fragment)
 

--- a/w3lib/url.py
+++ b/w3lib/url.py
@@ -26,7 +26,6 @@ from ._url import (
     RFC3986_UNRESERVED as RFC3986_UNRESERVED,
     RFC3986_USERINFO_SAFE_CHARS as RFC3986_USERINFO_SAFE_CHARS,
     _idna_bytes,
-    _idna_str,
     _parse_qs,
     _parse_qsl,
     _quote,
@@ -575,44 +574,6 @@ __all__ = [
 ]
 
 
-def _safe_ParseResult(
-    parts: ParseResult, encoding: str = "utf8", path_encoding: str = "utf8"
-) -> tuple[str, str, str, str, str, str]:
-    # IDNA encoding can fail for too long labels (>63 characters)
-    # or missing labels (e.g. http://.example.com)
-    try:
-        netloc = _idna_str(parts.netloc)
-    except UnicodeError:
-        netloc = parts.netloc
-
-    tmp_buf = bytearray()
-
-    _quote_into(parts.path.encode(path_encoding), tmp_buf, _PATH_SAFE_CHARS)
-    path = tmp_buf.decode()
-    tmp_buf.clear()
-
-    _quote_into(parts.params.encode(encoding), tmp_buf, _SAFE_CHARS)
-    params = tmp_buf.decode()
-    tmp_buf.clear()
-
-    _quote_into(parts.query.encode(encoding), tmp_buf, _SAFE_CHARS)
-    query = tmp_buf.decode()
-    tmp_buf.clear()
-
-    _quote_into(parts.fragment.encode(encoding), tmp_buf, _SAFE_CHARS)
-    fragment = tmp_buf.decode()
-    tmp_buf.clear()
-
-    return (
-        parts.scheme,
-        netloc,
-        path,
-        params,
-        query,
-        fragment,
-    )
-
-
 def canonicalize_url(
     url: str | bytes | ParseResult,
     keep_blank_values: bool = True,
@@ -649,20 +610,13 @@ def canonicalize_url(
     # UTF-8 can handle all Unicode characters,
     # so we should be covered regarding URL normalization,
     # if not for proper URL expected by remote website.
-    if isinstance(url, bytes):
-        # decode first (as parse_url would, UTF-8) so bytes input gets the
-        # same tab/newline/control stripping as str input below.
-        url = to_unicode(url)
-    if isinstance(url, str):
-        url = _strip(url)
+    if isinstance(url, ParseResult):
+        url = _urlunparse(*url)
     try:
-        scheme, netloc, path, params, query, fragment = _safe_ParseResult(
-            parse_url(url), encoding=encoding or "utf8"
-        )
+        url = safe_url_string(url, encoding=encoding or "utf8")
     except UnicodeEncodeError:
-        scheme, netloc, path, params, query, fragment = _safe_ParseResult(
-            parse_url(url), encoding="utf8"
-        )
+        url = safe_url_string(url, encoding="utf8")
+    scheme, netloc, path, params, query, fragment = _urlparse(url)
 
     # 1. decode query-string as UTF-8 (or keep raw bytes),
     #    sort values,

--- a/w3lib/url.py
+++ b/w3lib/url.py
@@ -30,6 +30,7 @@ from ._url import (
     _parse_qsl,
     _quote,
     _quote_into,
+    _split_params,
     _strip,
     _unquote,
     _url2pathname,
@@ -75,49 +76,12 @@ _SPECIAL_QUERY_SAFEST_CHARS = _PATH_SAFEST_CHARS.translate(None, delete=b"'")
 _FRAGMENT_SAFEST_CHARS = _PATH_SAFEST_CHARS
 
 
-def safe_url_string(
+def _safe_url_split(
     url: str | bytes,
     encoding: str = "utf8",
     path_encoding: str = "utf8",
     quote_path: bool = True,
-) -> str:
-    """Return a URL equivalent to *url* that a wide range of web browsers and
-    web servers consider valid.
-
-    *url* is parsed according to the rules of the `URL living standard`_,
-    and during serialization additional characters are percent-encoded to make
-    the URL valid by additional URL standards.
-
-    .. _URL living standard: https://url.spec.whatwg.org/
-
-    The returned URL should be valid by *all* of the following URL standards
-    known to be enforced by modern-day web browsers and web servers:
-
-    -   `URL living standard`_
-
-    -   `RFC 3986`_
-
-    -   `RFC 2396`_ and `RFC 2732`_, as interpreted by `Java 8’s java.net.URI
-        class`_.
-
-    .. _Java 8’s java.net.URI class: https://docs.oracle.com/javase/8/docs/api/java/net/URI.html
-    .. _RFC 2396: https://www.ietf.org/rfc/rfc2396.txt
-    .. _RFC 2732: https://www.ietf.org/rfc/rfc2732.txt
-    .. _RFC 3986: https://www.ietf.org/rfc/rfc3986.txt
-
-    If a bytes URL is given, it is first converted to `str` using the given
-    encoding (which defaults to 'utf-8'). If quote_path is True (default),
-    path_encoding ('utf-8' by default) is used to encode URL path component
-    which is then quoted. Otherwise, if quote_path is False, path component
-    is not encoded or quoted. Given encoding is used for query string
-    or form data.
-
-    When passing an encoding, you should use the encoding of the
-    original page (the page from which the URL was extracted from).
-
-    Calling this function on an already "safe" URL will return the URL
-    unmodified.
-    """
+) -> tuple[str, str, str, str, str]:
     # urlsplit() chokes on bytes input with non-ASCII chars,
     # so let's decode (to Unicode) using page encoding:
     #   - it is assumed that a raw bytes input comes from a document
@@ -193,13 +157,59 @@ def safe_url_string(
     else:
         fragment = parts.fragment
 
-    return _urlunsplit(
+    return (
         parts.scheme,
         netloc,
         path,
         query,
         fragment,
     )
+
+
+def safe_url_string(
+    url: str | bytes,
+    encoding: str = "utf8",
+    path_encoding: str = "utf8",
+    quote_path: bool = True,
+) -> str:
+    """Return a URL equivalent to *url* that a wide range of web browsers and
+    web servers consider valid.
+
+    *url* is parsed according to the rules of the `URL living standard`_,
+    and during serialization additional characters are percent-encoded to make
+    the URL valid by additional URL standards.
+
+    .. _URL living standard: https://url.spec.whatwg.org/
+
+    The returned URL should be valid by *all* of the following URL standards
+    known to be enforced by modern-day web browsers and web servers:
+
+    -   `URL living standard`_
+
+    -   `RFC 3986`_
+
+    -   `RFC 2396`_ and `RFC 2732`_, as interpreted by `Java 8’s java.net.URI
+        class`_.
+
+    .. _Java 8’s java.net.URI class: https://docs.oracle.com/javase/8/docs/api/java/net/URI.html
+    .. _RFC 2396: https://www.ietf.org/rfc/rfc2396.txt
+    .. _RFC 2732: https://www.ietf.org/rfc/rfc2732.txt
+    .. _RFC 3986: https://www.ietf.org/rfc/rfc3986.txt
+
+    If a bytes URL is given, it is first converted to `str` using the given
+    encoding (which defaults to 'utf-8'). If quote_path is True (default),
+    path_encoding ('utf-8' by default) is used to encode URL path component
+    which is then quoted. Otherwise, if quote_path is False, path component
+    is not encoded or quoted. Given encoding is used for query string
+    or form data.
+
+    When passing an encoding, you should use the encoding of the
+    original page (the page from which the URL was extracted from).
+
+    Calling this function on an already "safe" URL will return the URL
+    unmodified.
+    """
+    return _urlunsplit(*_safe_url_split(url, encoding, path_encoding, quote_path))
 
 
 _parent_dirs = re.compile(r"/?(\.\./)+")
@@ -613,10 +623,12 @@ def canonicalize_url(
     if isinstance(url, ParseResult):
         url = _urlunparse(*url)
     try:
-        url = safe_url_string(url, encoding=encoding or "utf8")
+        scheme, netloc, path, query, fragment = _safe_url_split(
+            url, encoding=encoding or "utf8"
+        )
     except UnicodeEncodeError:
-        url = safe_url_string(url, encoding="utf8")
-    scheme, netloc, path, params, query, fragment = _urlparse(url)
+        scheme, netloc, path, query, fragment = _safe_url_split(url, encoding="utf8")
+    path, params = _split_params(scheme, path)
 
     # 1. decode query-string as UTF-8 (or keep raw bytes),
     #    sort values,

--- a/w3lib/url.py
+++ b/w3lib/url.py
@@ -649,6 +649,10 @@ def canonicalize_url(
     # UTF-8 can handle all Unicode characters,
     # so we should be covered regarding URL normalization,
     # if not for proper URL expected by remote website.
+    if isinstance(url, bytes):
+        # decode first (as parse_url would, UTF-8) so bytes input gets the
+        # same tab/newline/control stripping as str input below.
+        url = to_unicode(url)
     if isinstance(url, str):
         url = _strip(url)
     try:


### PR DESCRIPTION
    >>> canonicalize_url("http://exa\tmple.com/")
    'http://example.com/'
    >>> canonicalize_url(b"http://exa\tmple.com/")
    'http://exa\tmple.com/'

canonicalize_url runs the WHATWG cleanup (`_strip`, which drops ASCII tab/CR/LF from anywhere in the URL) only inside `if isinstance(url, str)`, so bytes input skips it and a tab stays in the host of the canonical form. A browser strips that tab and connects to `example.com`, so the value used for dedup/allowlist comparison no longer matches the resolved host. `safe_url_string` avoids this by running `_strip(to_unicode(url, ...))` for both types; decode bytes the same way (UTF-8, as `parse_url` already does) before `_strip`.