### PR TITLE
reject NFKC-introduced backslash in _checknetloc

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -388,6 +388,10 @@ SAFE_URL_URL_CASES = (
     ("https://example\uff03.com", ValueError),
     ("https://example\uff1f.com", ValueError),
     ("https://example\uff20.com", ValueError),
+    # "\" ends the authority of a special-scheme URL, and both of these
+    # normalise to "\" under NFKC, so they must be rejected like the others.
+    ("https://evil.com\uff3c.example.com", ValueError),
+    ("https://evil.com\ufe68.example.com", ValueError),
     # changed after NFKC normalisation
     ("https://examplｅ.com", "https://example.com"),
     # "[" and "]" outside the authority are ordinary characters and must not

--- a/w3lib/_url.py
+++ b/w3lib/_url.py
@@ -54,7 +54,9 @@ _C0_CONTROL_OR_SPACE_RE = re.compile(rf"[{_C0_CONTROL_OR_SPACE}]")
 _SCHEME_RE = re.compile(rf"^([a-zA-Z][{scheme_chars}]*):")
 
 _IPV_FUTURE_RE = re.compile(r"\Av[a-fA-F0-9]+\..+\Z")
-_NETLOC_DELIMS_RE = re.compile(r"[/?#@:]")
+# "\" terminates the authority of a special-scheme URL just like "/" under the
+# URL living standard, so it belongs with the other authority delimiters here.
+_NETLOC_DELIMS_RE = re.compile(r"[/?#@:\\]")
 _NETLOC_STRIP_CHARS = str.maketrans("", "", "@:#?")
 
 


### PR DESCRIPTION
    >>> safe_url_string("https://evil.com＼.example.com")
    'https://evil.com\\.example.com'

_checknetloc raises when NFKC normalization introduces an authority delimiter,
but _NETLOC_DELIMS_RE lists /?#@: and leaves out "\". For special schemes the
URL living standard ends the authority at "\" (which is also a forbidden host
code point), so U+FF3C and U+FE68 pass the guard and IDNA writes a literal "\"
into the host; a browser then reads the authority as evil.com, not the host
_urlsplit returned. The fullwidth : # ? @ / siblings already raise, so this
adds "\" to the same character class. canonicalize_url reaches the same guard.
