### PR TITLE
add userinfo regression tests for canonicalize_url with IDN hosts

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -1536,6 +1536,18 @@ class TestCanonicalizeUrl:
             == "http://www.xn--bcher-kva.de:8080/?q=b%C3%BCcher"
         )
 
+    def test_canonicalize_idns_with_userinfo(self):
+        # userinfo must survive with its "@" delimiter instead of being
+        # folded into the IDNA host label
+        assert (
+            canonicalize_url("http://user@例え.jp/path")
+            == "http://user@xn--r8jz45g.jp/path"
+        )
+        assert (
+            canonicalize_url("http://user:pass@例え.jp:8080/p")
+            == "http://user:pass@xn--r8jz45g.jp:8080/p"
+        )
+
     def test_quoted_slash_and_question_sign(self):
         assert (
             canonicalize_url("http://foo.com/AC%2FDC+rocks%3f/?yeah=1")


### PR DESCRIPTION
Originally a fix for _safe_ParseResult folding userinfo and port into the IDNA host label. #279 removed that code path and routes canonicalize_url through safe_url_string, which already encodes only the host, so the fix itself is no longer needed. Rebased down to the regression tests that don't exist on master: userinfo with an IDN host, and userinfo plus port with an IDN host. The plain host-with-port case was dropped since test_canonicalize_idns already covers it.