### PR TITLE
fix: handle empty quoted charset in parse_data_uri

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -1679,6 +1679,17 @@ class TestDataURI:
         assert result.media_type_parameters == {"charset": "iso-8859-7"}
         assert result.data == b"\xbe\xd3\xbe"
 
+    def test_empty_quoted_charset(self):
+        result = parse_data_uri('data:text/plain;charset="",hi')
+        assert result.media_type == "text/plain"
+        assert result.media_type_parameters == {"charset": ""}
+        assert result.data == b"hi"
+
+        result = parse_data_uri('data:;charset="",A%20brief%20note')
+        assert result.media_type == "text/plain"
+        assert result.media_type_parameters == {"charset": ""}
+        assert result.data == b"A brief note"
+
     def test_mediatype_parameters(self):
         result = parse_data_uri(
             "data:text/plain;"

--- a/w3lib/url.py
+++ b/w3lib/url.py
@@ -545,7 +545,8 @@ def parse_data_uri(uri: str | bytes) -> ParseDataURIResult:
 
     while m := _mediatype_parameter_pattern.match(uri):
         attribute, value, value_quoted = m.groups()
-        if value_quoted:
+        # Empty quoted values (charset="") are valid; only None means token form.
+        if value_quoted is not None:
             value = re.sub(rb"\\(.)", rb"\1", value_quoted)
         media_type_params[attribute.decode()] = value.decode()
         uri = uri[m.end() :]


### PR DESCRIPTION
w3lib.url.parse_data_uri hits AttributeError when data:text/plain;charset=\"\",. This PR fixes the regression with a focused test covering the case.
