### PR TITLE
Decode case-sensitive HTML named entities via the HTML5 table

### DIFF
--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -33,6 +33,17 @@ class TestRemoveEntities:
             == "redirectTo=search&searchtext=MR0221Y&aff=buyat&affsrc=d_data&cm_mmc=buyat-_-ELECTRICAL & SEASONAL-_-MR0221Y-_-9-carat gold \xbdoz solid crucifix pendant"
         )
 
+    def test_case_sensitive_named_entities(self):
+        # HTML named entities are case-sensitive: &Gt;/&Lt; are the "much
+        # greater/less-than" signs, not the &gt;/&lt; characters, and &apos;
+        # must be decoded rather than dropped.
+        assert replace_entities("&Gt;") == "≫"
+        assert replace_entities("&Lt;") == "≪"
+        assert replace_entities("x &gt; y &lt; z") == "x > y < z"
+        assert replace_entities("it&apos;s") == "it's"
+        # legacy upper-case spellings still resolve
+        assert replace_entities("&AMP; &COPY;") == "& \xa9"
+
     def test_keep_entities(self):
         # keep some entities
         assert (

--- a/w3lib/html.py
+++ b/w3lib/html.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import functools
 import re
-from html.entities import name2codepoint
+from html.entities import html5
 from typing import TYPE_CHECKING
 from urllib.parse import urljoin
 
@@ -85,13 +85,19 @@ def replace_entities(
         elif groups.get("hex"):
             number = int(groups["hex"], 16)
         else:
-            # guaranteed to be named
+            # Guaranteed to be named. HTML entity names are case-sensitive
+            # (&Gt; is U+226B, not the &gt; character), so resolve the exact-
+            # cased name against the HTML5 table that html.unescape uses,
+            # rather than the HTML 4 name2codepoint with a .lower() fallback --
+            # that fallback silently mapped case-only variants to the wrong
+            # character and dropped names missing from the HTML 4 set.
             entity_name = groups["named"]
             if entity_name.lower() in keep:
                 return m.group(0)
-            number = name2codepoint.get(entity_name) or name2codepoint.get(
-                entity_name.lower()
-            )
+            key = entity_name + ";" if groups.get("semicolon") else entity_name
+            char = html5.get(key)
+            if char is not None:
+                return char
         if number is not None:
             # Numeric character references in the 80-9F range are typically
             # interpreted by browsers as representing the characters mapped


### PR DESCRIPTION
`replace_entities` resolved named entities through `html.entities.name2codepoint`
(the HTML 4 set) with a `.lower()` fallback. HTML entity names are case-sensitive,
so when the exact-cased name wasn't in the HTML 4 table the fallback returned a
*different* valid character:

```python
>>> from w3lib.html import replace_entities
>>> replace_entities("&Gt;")   # should be ≫ (U+226B)
'>'
>>> replace_entities("&Lt;")   # should be ≪ (U+226A)
'<'
>>> replace_entities("it&apos;s")   # should be it's
'its'
```

`&Gt;`/`&Lt;` collapsing to `>`/`<` is worse than a miss: the extracted text is
corrupted and can be re-read as tag delimiters downstream. Names missing from
HTML 4 (like `&apos;`, which `encoding.py` itself already treats as real) were
dropped. Realistic inputs are MathML / scientific pages using these entities.

Fix: resolve the exact-cased name against `html.entities.html5` — the table
`html.unescape` uses — keyed by the name plus its trailing semicolon when
present. Numeric references are untouched, and the full suite plus a new
case-sensitivity test pass.

---
This PR was authored by an AI coding agent (Claude Code) running on this account:
the AI found the bug, ran the repro, wrote the test, and wrote this description.
The human account holder reviews every change and is accountable for it. The
verification is real and re-runnable from the diff. If this isn't the kind of
contribution you want, say so and I'll close it.
