### PR TITLE
treat backslash as slash for special-scheme urls in _urlsplit

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -220,6 +220,10 @@ SAFE_URL_URL_CASES = (
         f"https://{USERNAME_ENCODED}:{PASSWORD_ENCODED}@example.com",
     ),
     ("https://@\\example.com", ValueError),
+    # "\" ends the authority of a special-scheme URL, so a "\" before "@" is
+    # not a userinfo separator: the host is what precedes the "\".
+    ("https://evil.com\\@good.com/", "https://evil.com/@good.com/"),
+    ("https://good.com\\@evil.com/", "https://good.com/@evil.com/"),
     ("https://\x80:\x80@example.com", "https://%C2%80:%C2%80@example.com"),
     # Host
     ("https://example.com", "https://example.com"),
@@ -477,12 +481,8 @@ KNOWN_SAFE_URL_STRING_URL_ISSUES = {
     "http://192.168.0.256",  # Invalid IP address
     "http://192.168.0.0.0",  # Invalid IP address / domain name
     "https://example.com:",  # Removes the :
-    # Does not convert \ to /
-    "https://example.com\\a",
-    "https://example.com\\a\\b",
-    # Encodes \ and / after the first one in the path
+    # Encodes / after the first one in the path
     "https://example.com/a/b",
-    "https://example.com/a\\b",
     # Some path characters that RFC 2396 and RFC 3986 require escaping (%)
     # are not escaped.
     f"https://example.com/{PATH_TO_ENCODE}",

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -481,8 +481,6 @@ KNOWN_SAFE_URL_STRING_URL_ISSUES = {
     "http://192.168.0.256",  # Invalid IP address
     "http://192.168.0.0.0",  # Invalid IP address / domain name
     "https://example.com:",  # Removes the :
-    # Encodes / after the first one in the path
-    "https://example.com/a/b",
     # Some path characters that RFC 2396 and RFC 3986 require escaping (%)
     # are not escaped.
     f"https://example.com/{PATH_TO_ENCODE}",

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -323,6 +323,12 @@ SAFE_URL_URL_CASES = (
     ("https://example.com/a", "https://example.com/a"),
     ("https://example.com\\a", "https://example.com/a"),
     ("https://example.com/a\\b", "https://example.com/a/b"),
+    # "\" is only converted to "/" before the query/fragment; inside them it
+    # is percent-encoded as usual.
+    ("https://example.com\\a?b\\c", "https://example.com/a?b%5Cc"),
+    ("https://example.com\\a#b\\c", "https://example.com/a#b%5Cc"),
+    ("https://example.com\\a?b\\c#d\\e", "https://example.com/a?b%5Cc#d%5Ce"),
+    ("https://example.com\\a#b?c\\d", "https://example.com/a#b?c%5Cd"),
     (
         f"https://example.com/{PATH_SAFE}",
         f"https://example.com/{PATH_SAFE}",

--- a/w3lib/_url.py
+++ b/w3lib/_url.py
@@ -648,6 +648,21 @@ def _urlsplit(  # pylint: disable=too-many-locals,too-many-statements
         scheme = m.group(1).lower()
         url = url[m.end() :]
 
+    # The URL living standard treats "\" like "/" for special-scheme URLs, but
+    # only in the authority and path; a "\" in the query or fragment is left
+    # alone. Without this, "http://evil.com\@good.com/" is read as userinfo
+    # "evil.com\" plus host "good.com", while a browser ends the authority at
+    # the "\" and connects to "evil.com".
+    if scheme in _SPECIAL_SCHEMES and "\\" in url:
+        cut = len(url)
+        question_idx = url.find("?")
+        if question_idx != -1:
+            cut = question_idx
+        hash_idx = url.find("#")
+        if hash_idx != -1 and hash_idx < cut:
+            cut = hash_idx
+        url = url[:cut].replace("\\", "/") + url[cut:]
+
     # The scan skips the leading "//" of an authority; for URLs without an
     # authority it must start at 0, otherwise a "?" or "#" at index 0 or 1
     # (e.g. relative URLs like "a?b" or "a#f") is never recorded.


### PR DESCRIPTION
**Backslash is not treated as an authority delimiter in _urlsplit**

Under the URL living standard "\" behaves like "/" for special schemes, so a browser reads `http://evil.com\@good.com/` as host `evil.com`, but `_urlsplit` treated the backslash as an ordinary character and reported `good.com` with userinfo `evil.com\`, disagreeing with the fetched host. This converts "\" to "/" in the authority and path of special-scheme URLs (query and fragment are left as-is), which also flips the two `\`-to-`/` reference cases that were parked as xfails in `test_url.py`.