### PR TITLE
only treat a last-segment semicolon as params in _split_params

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -14,7 +14,7 @@ from w3lib._infra import (
     _ASCII_TAB_OR_NEWLINE,
     _C0_CONTROL_OR_SPACE,
 )
-from w3lib._url import _SPECIAL_SCHEMES, _urlunparse, _urlunsplit
+from w3lib._url import _SPECIAL_SCHEMES, _split_params, _urlunparse, _urlunsplit
 from w3lib.url import (
     add_or_replace_parameter,
     add_or_replace_parameters,
@@ -1612,6 +1612,27 @@ class TestCanonicalizeUrl:
         parts = parse_url("http://www.example.com/path;params?x=1#frag")
         assert parse_url(parts) is parts
 
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://www.example.com/public;/../admin/secret",
+            "http://www.example.com/dir;x/file",
+            "http://www.example.com/a;b/c",
+            "http://www.example.com/a;b/c;d",
+        ],
+    )
+    def test_parse_url_non_final_segment_semicolon(self, url):
+        # a ";" outside the last path segment is not a params delimiter
+        assert parse_url(url).path == urlparse(url).path
+        assert parse_url(url).params == urlparse(url).params
+
+    def test_canonicalize_url_non_final_segment_semicolon(self):
+        # the path after such a ";" still gets percent-encoding normalization
+        assert (
+            canonicalize_url("http://www.example.com/dir;x/a%7Eb")
+            == "http://www.example.com/dir;x/a~b"
+        )
+
     def test_canonicalize_url_idempotence(self):
         for url, enc in [
             ("http://www.bücher.de/résumé?q=résumé", "utf8"),
@@ -1859,3 +1880,28 @@ class TestPrivateHelpers:
     )
     def test_urlunparse(self, components, expected):
         assert _urlunparse(*components) == expected
+
+    @pytest.mark.parametrize(
+        ("path", "expected"),
+        [
+            # a ";" in the last segment starts the params
+            ("/a;b", ("/a", "b")),
+            ("/a/b;c", ("/a/b", "c")),
+            ("/a;b/c;d", ("/a;b/c", "d")),
+            ("/a;b/c;", ("/a;b/c", "")),
+            # a ";" in an earlier segment is an ordinary path character
+            ("/a;b/c", ("/a;b/c", "")),
+            ("/dir;x/file", ("/dir;x/file", "")),
+            ("/public;/../admin/secret", ("/public;/../admin/secret", "")),
+            # without a "/" the first ";" starts the params
+            ("a;b", ("a", "b")),
+            (";a", ("", "a")),
+            # no ";" at all
+            ("/a/b", ("/a/b", "")),
+            ("", ("", "")),
+        ],
+    )
+    def test_split_params(self, path, expected):
+        assert _split_params("http", path) == expected
+        # schemes that do not use params keep the path intact
+        assert _split_params("data", path) == (path, "")

--- a/w3lib/_url.py
+++ b/w3lib/_url.py
@@ -436,14 +436,11 @@ def _urlencode(query: _QueryType) -> bytes:
 def _split_params(scheme: str, url: str) -> tuple[str, str]:
     """Split the params from the path, as urlib.parse.urlparse does."""
     if scheme in _USES_PARAMS:
-        semi_idx = url.find(";")
+        # Only a ";" in the last segment starts the params; one in an earlier
+        # segment is an ordinary path character.
+        semi_idx = url.find(";", url.rfind("/") + 1)
 
         if semi_idx != -1:
-            slash_idx = url.rfind("/")
-
-            if slash_idx != -1 and slash_idx < semi_idx:
-                semi_idx = url.find(";", slash_idx)
-
             return url[:semi_idx], url[semi_idx + 1 :]
 
     return url, ""


### PR DESCRIPTION
Structured differential of `_urlparse` against `urllib.parse.urlparse` over 780 path shapes:

    220/780 inputs where (path, params) differs from stdlib
      'http://h/a;/c'   w3lib=('/a', '/c')    stdlib=('/a;/c', '')
      'http://h/;a/c'   w3lib=('/', 'a/c')    stdlib=('/;a/c', '')

Params start at the first ";" of the *last* path segment, but `_split_params` cuts at the first ";" anywhere. The re-scan guard is dead code: it runs only when `slash_idx < semi_idx`, and there `url.find(";", slash_idx)` returns that same `semi_idx`. The case it was written for, a ";" in an earlier segment, falls through and splits there.

Both public entry points see it. `parse_url("http://example.com/public;/../admin/secret").path` is `/public`, so a path check reads a different path than the server resolves. `canonicalize_url` passes everything after that ";" to `_urlunparse` unnormalized, so `/dir;x/a%7Eb` and `/dir;x/a~b` canonicalize differently and stop deduplicating.

Predates the `_split_params` extraction in #279; the logic came from the hand-inlining of `_splitparams` in 85ed848. Differential is 0/780 after the change, and the new tests fail without it.