### PR TITLE
match only ascii digits in _ent_re and _META_INT_URL

### DIFF
--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -76,6 +76,17 @@ class TestRemoveEntities:
         assert replace_entities("x&#153;y", encoding="cp1252") == "x\u2122y"
         assert replace_entities("x&#x99;y", encoding="cp1252") == "x\u2122y"
 
+    def test_non_ascii_digits(self):
+        # character references are ASCII digits only, so these are plain text
+        assert (
+            replace_entities("&#\u0666\u0660;script&#\u0666\u0662;")
+            == "&#\u0666\u0660;script&#\u0666\u0662;"
+        )
+        assert replace_entities("&#x\u0663C;") == "&#x\u0663C;"
+        assert replace_entities("&#\u0660\u0666\u0660;") == "&#\u0660\u0666\u0660;"
+        # the named reference still ends where the ASCII digits do
+        assert replace_entities("&nbsp\u0664;") == "\xa0\u0664;"
+
     def test_missing_semicolon(self):
         for entity, result in (
             ("&lt&lt!", "<<!"),
@@ -570,6 +581,12 @@ class TestGetMetaRefresh:
         baseurl = "http://example.org"
         body = """<meta http-equiv="refresh" content="3; url=&#39;http://www.example.com/other&#39;">"""
         assert get_meta_refresh(body, baseurl) == (3, "http://www.example.com/other")
+
+    def test_non_ascii_digit_interval(self):
+        # the interval is ASCII digits only, so this is not a refresh
+        baseurl = "http://example.org"
+        body = """<meta http-equiv="refresh" content="٥; url=http://example.org/x">"""
+        assert get_meta_refresh(body, baseurl) == (None, None)
 
     def test_relative_redirects(self):
         # relative redirects

--- a/w3lib/html.py
+++ b/w3lib/html.py
@@ -17,8 +17,10 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
 
+# Character references are ASCII digits only; \d would also match the Unicode
+# decimal digits, which int() accepts but no HTML parser decodes.
 _ent_re = re.compile(
-    r"&((?P<named>[a-z\d]+)|#(?P<dec>\d+)|#x(?P<hex>[a-f\d]+))(?P<semicolon>;?)",
+    r"&((?P<named>[a-z0-9]+)|#(?P<dec>[0-9]+)|#x(?P<hex>[a-f0-9]+))(?P<semicolon>;?)",
     re.IGNORECASE,
 )
 _tag_re = re.compile(r"<[a-zA-Z\/!][^<>]*>")
@@ -36,9 +38,8 @@ def _upto(literal: str) -> str:
 
 
 # The interval/url payload shared by both orderings: ``content="3; url=..."``.
-_META_INT_URL = (
-    r'\s*=\s*(?P<quote>["\'])(?P<int>(\d*\.)?\d+)\s*;\s*url=\s*(?P<url>.*?)(?P=quote)'
-)
+# The interval is ASCII digits only, as in the HTML refresh steps.
+_META_INT_URL = r'\s*=\s*(?P<quote>["\'])(?P<int>([0-9]*\.)?[0-9]+)\s*;\s*url=\s*(?P<url>.*?)(?P=quote)'
 _meta_refresh_re = re.compile(
     r"<meta\s"
     + _upto("http-equiv")


### PR DESCRIPTION
Python 3.14, master at 54ee9e6:

    >>> replace_entities("&#٦٠;script&#٦٢;")
    '<script>'
    >>> html.unescape("&#٦٠;script&#٦٢;")
    '&#٦٠;script&#٦٢;'
    >>> get_meta_refresh('<meta http-equiv="refresh" content="٥; url=http://example.org/x">')
    (5.0, 'http://example.org/x')

`\d` matches every Unicode decimal digit and `int()`/`float()` take them, so both
regexes read references and refresh intervals no HTML parser decodes. The character
reference states consume ASCII digits only, and the shared declarative refresh steps
return without refreshing when no ASCII digit is collected and the next code point is
not `.`, so a browser leaves both inputs above alone. Spelled the classes out as
`[0-9]`, the way CPython's `html._charref` is written.

The named group has the same `\d`, which also drops text: `&nbsp٤;` returned `''`
rather than `'\xa0٤;'`.

Valid ASCII references and intervals are unchanged. Both new tests fail on master.
