### PR TITLE
skip quoted-string parameter values in http_content_type_encoding

### DIFF
--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -98,6 +98,28 @@ class TestRequestEncoding:
         assert http_content_type_encoding("text/html; mycharset=utf-8") is None
         # invalid: orphan quote in unquoted value
         assert http_content_type_encoding('text/html; charset=utf-8x"') is None
+        # the parameter is still found when the header does not end right
+        # after it
+        assert (
+            http_content_type_encoding("text/html;charset=utf-8, text/html") == "utf-8"
+        )
+        assert (
+            http_content_type_encoding('text/html; charset="utf-8", text/html')
+            == "utf-8"
+        )
+        assert (
+            http_content_type_encoding("Content-Type: text/html; charset=utf-8\r\n")
+            == "utf-8"
+        )
+        # comma-joined headers with differing essences: the first charset
+        # wins, unlike Fetch's extract-a-MIME-type where the last valid MIME
+        # type's would
+        assert (
+            http_content_type_encoding(
+                "text/html; charset=utf-8, text/plain; charset=utf-16"
+            )
+            == "utf-8"
+        )
 
     def test_html_body_declared_encoding(self):
         for fragment in self.utf8_fragments:

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -108,6 +108,22 @@ class TestRequestEncoding:
             == "utf-8"
         )
         assert http_content_type_encoding('text/html; foo="bar; charset=utf-7"') is None
+        assert (
+            http_content_type_encoding('text/html; foo="bar; charset=utf-7;"') is None
+        )
+        assert (
+            http_content_type_encoding(
+                'text/html; foo="bar; charset=utf-7;"; charset="utf-8"'
+            )
+            == "utf-8"
+        )
+        # an invalid charset value is skipped and the scan continues
+        assert (
+            http_content_type_encoding(
+                'text/html; foo="bar; charset=utf-7;"; charset=""; charset=utf-8'
+            )
+            == "utf-8"
+        )
         # the parameter is still found when the header does not end right
         # after it
         assert (

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -60,7 +60,8 @@ class TestRequestEncoding:
         extracted = http_content_type_encoding(header_value)
         assert extracted == "iso8859-4"
         assert http_content_type_encoding("something else") is None
-        # valid quoted charset values (RFC 7231 sec. 3.1.1.1)
+        # valid quoted charset values
+        # (https://mimesniff.spec.whatwg.org/#parse-a-mime-type)
         assert (
             http_content_type_encoding('Content-Type: text/html; charset="utf-8"')
             == "utf-8"
@@ -98,6 +99,15 @@ class TestRequestEncoding:
         assert http_content_type_encoding("text/html; mycharset=utf-8") is None
         # invalid: orphan quote in unquoted value
         assert http_content_type_encoding('text/html; charset=utf-8x"') is None
+        # a quoted-string is opaque: a charset written inside another
+        # parameter's value belongs to that value
+        assert (
+            http_content_type_encoding(
+                'text/html; foo="bar; charset=utf-7;"; charset=utf-8'
+            )
+            == "utf-8"
+        )
+        assert http_content_type_encoding('text/html; foo="bar; charset=utf-7"') is None
         # the parameter is still found when the header does not end right
         # after it
         assert (

--- a/w3lib/encoding.py
+++ b/w3lib/encoding.py
@@ -27,6 +27,30 @@ _HEADER_ENCODING_RE = re.compile(
     r"(?![^\s;,])",
     re.IGNORECASE,
 )
+# https://mimesniff.spec.whatwg.org/commit-snapshots/39aa53511b13953d84fef8d4131d6f61d0ccbde6/#parse-a-mime-type
+# Parameters are ";"-separated name=value pairs whose value is either a token
+# or a quoted-string, and a quoted-string is opaque
+# (https://fetch.spec.whatwg.org/commit-snapshots/586cd2a44c2a865b37c166dc0740f3fb8bb220d6/#collect-an-http-quoted-string),
+# so it has to be consumed as a whole: a "charset=" written inside one belongs
+# to that value and is not a parameter of its own.
+_HEADER_PARAMETER_RE = re.compile(
+    r"(?:^|;)[ \t]*(?P<name>[^\s;=]+)="
+    r'(?:"(?P<quoted>[^"\\]*(?:\\.[^"\\]*)*)"(?![^\s;,])'
+    r"|(?P<token>[^;,\s]*))"
+)
+_ENCODING_LABEL_RE = re.compile(r"[\w-]+")
+
+
+def _quoted_aware_charset(content_type: str) -> str | None:
+    for match in _HEADER_PARAMETER_RE.finditer(content_type):
+        if match.group("name").lower() != "charset":
+            continue
+        label = match.group("quoted")
+        if label is None:
+            label = match.group("token")
+        if _ENCODING_LABEL_RE.fullmatch(label):
+            return resolve_encoding(label)
+    return None
 
 
 def http_content_type_encoding(content_type: str | None) -> str | None:
@@ -41,7 +65,12 @@ def http_content_type_encoding(content_type: str | None) -> str | None:
     if content_type:
         match = _HEADER_ENCODING_RE.search(content_type)
         if match:
-            return resolve_encoding(match.group(1) or match.group(2))
+            # A match inside a quoted-string must be preceded by that string's
+            # opening quote, so if no '"' precedes it the fast answer is
+            # correct; only otherwise walk the parameters.
+            if content_type.find('"', 0, match.start()) < 0:
+                return resolve_encoding(match.group(1) or match.group(2))
+            return _quoted_aware_charset(content_type)
 
     return None
 

--- a/w3lib/encoding.py
+++ b/w3lib/encoding.py
@@ -17,10 +17,14 @@ if TYPE_CHECKING:
 
     from w3lib._types import AnyUnicodeError
 
+# The value ends at whitespace, ";", "," or the end of the header. Comma is
+# not parameter syntax; stopping the value at "," approximates Fetch's
+# "extract a MIME type" for comma-joined duplicate headers, keeping the first
+# charset rather than the last valid MIME type's.
 _HEADER_ENCODING_RE = re.compile(
-    r"(?:^|;[ \t]*)charset="
+    r"(?:^|;)[ \t]*charset="
     r'(?:"([\w-]+)"|([\w-]+))'
-    r"(?=[ \t]*(?:;|$))",
+    r"(?![^\s;,])",
     re.IGNORECASE,
 )
 


### PR DESCRIPTION
This fixes a regression from #291: the trailing `(?=[ \t]*(?:;|$))` lookahead
added there drops a valid charset whenever anything follows it. On current
master:

    'text/html;charset=utf-8, text/html'          -> None
    'Content-Type: text/html; charset=utf-8\r\n'  -> None  (the docstring's own form)
    'text/html; charset="utf-8", text/html'       -> None

`html_to_unicode` then falls through to the `<meta>` prescan, which the
response body controls, even though the transport layer outranks it. Since
comma-joined duplicate headers are exactly what Scrapy hands this function,
this is worth landing before the next release.

It also fixes the pre-existing quoted-string bug the lookahead didn't touch:

    >>> http_content_type_encoding('text/html; foo="bar; charset=utf-7;"; charset=utf-8')
    'utf-7'   # master; the real parameter is utf-8

Per mimesniff's "parse a MIME type", a parameter value is a token or a
quoted-string, and a quoted-string is opaque, so the `charset=` inside `foo`'s
value is not a parameter of its own; the scan has to consume the quoted value
whole. The code comments cite the mimesniff and Fetch commit snapshots, same
style as `_url.py` and `_infra.py`.

Comma is not a parameter delimiter in mimesniff; stopping a value at `,` is an
approximation of Fetch's "extract a MIME type" for comma-joined duplicate
headers. For differing essences it keeps the first charset where Fetch would
take the last valid MIME type's; a test pins
`'text/html; charset=utf-8, text/plain; charset=utf-16'` -> `'utf-8'`.

On "why not the stdlib": `email.message_from_string(...).get_param("charset")`
is not a drop-in. It parses RFC 2045 rather than WHATWG and returns
`'utf-8, text/html'` for the comma case and `'utf-8x"; charset=utf-16'` for
the orphan-quote input an existing test pins to None.

All 20 existing assertions keep their results, and the parameter walk stays
linear on adversarial input.
