### PR TITLE
Fix remove_tags with greater-than in quoted attributes

### DIFF
--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -207,6 +207,20 @@ class TestRemoveTags:
             == '<p align="center" class="one">texty</p>'
         )
 
+    def test_remove_tags_with_gt_in_quoted_attribute(self):
+        assert remove_tags('<a title="x>y">texty</a>') == "texty"
+        assert remove_tags("<a title='x>y'>texty</a>") == "texty"
+        assert (
+            remove_tags('<a title="x>y">texty</a>', which_ones=("b",))
+            == '<a title="x>y">texty</a>'
+        )
+        assert remove_tags('<p>a<br title="x>y" />b</p>', keep=("br",)) == (
+            'a<br title="x>y" />b'
+        )
+
+    def test_remove_tags_with_unquoted_quote_in_attribute(self):
+        assert remove_tags('<a b=c"d>keep</a>') == "keep"
+
     def test_remove_empty_tags(self):
         # text with empty tags
         assert remove_tags("a<br />b<br/>c") == "abc"

--- a/w3lib/html.py
+++ b/w3lib/html.py
@@ -60,22 +60,11 @@ _meta_refresh_re2 = re.compile(
 
 _CDATA_START = "<![CDATA["
 _CDATA_END = "]]>"
-_tags_re = re.compile(
-    r"""
-    </?             # opening angle bracket, optional slash for a closing tag
-    ([^ <>/]+)      # tag name (captured): a run of non-space, non-bracket chars,
-    (?![^ <>/])     # pinned to its maximal length by this lookahead so it can't
-                    # overlap the run below and backtrack quadratically on an
-                    # unterminated tag (a "<" with a long run and no ">")
-    [^<>]*          # the rest of the tag: attributes, whitespace, etc.
-    >               # closing angle bracket
-    """,
-    re.IGNORECASE | re.VERBOSE,
-)
 _meta_tag_re = re.compile(r"<meta\b[^<>]*>", re.IGNORECASE)
 
 
 HTML5_WHITESPACE = " \t\n\r\x0c"
+_TAG_NAME_END = " <>/"
 
 
 def replace_entities(
@@ -189,14 +178,65 @@ def remove_comments(text: str | bytes, encoding: str | None = None) -> str:
     return _REMOVECOMMENTS_RE.sub("", utext)
 
 
-def _remove_tag(
-    m: re.Match[str], which_ones: set[str] | tuple[()], keep: set[str] | tuple[()]
+def _read_tag(text: str, start: int) -> tuple[int, str] | None:
+    position = start + 1
+    if position >= len(text):
+        return None
+    if text[position] == "/":
+        position += 1
+    if position >= len(text) or text[position] in _TAG_NAME_END:
+        return None
+
+    tag_start = position
+    while position < len(text) and text[position] not in _TAG_NAME_END:
+        position += 1
+    tag = text[tag_start:position]
+
+    quote: str | None = None
+    after_equals = False
+    while position < len(text):
+        char = text[position]
+        if quote is not None:
+            if char == quote:
+                quote = None
+                after_equals = False
+        elif char == "<":
+            return None
+        elif char == ">":
+            return position + 1, tag
+        elif char in "\"'" and after_equals:
+            quote = char
+        elif char == "=":
+            after_equals = True
+        elif after_equals and char not in HTML5_WHITESPACE:
+            after_equals = False
+        position += 1
+    return None
+
+
+def _remove_tags(
+    text: str, which_ones: set[str] | tuple[()], keep: set[str] | tuple[()]
 ) -> str:
-    tag = m.group(1).lower()
-
-    should_remove = tag in which_ones if which_ones else tag not in keep
-
-    return "" if should_remove else m.group(0)
+    result = []
+    position = 0
+    while position < len(text):
+        start = text.find("<", position)
+        if start == -1:
+            result.append(text[position:])
+            break
+        result.append(text[position:start])
+        tag = _read_tag(text, start)
+        if tag is None:
+            result.append(text[start])
+            position = start + 1
+            continue
+        end, tag_name = tag
+        tag_name = tag_name.lower()
+        should_remove = tag_name in which_ones if which_ones else tag_name not in keep
+        if not should_remove:
+            result.append(text[start:end])
+        position = end
+    return "".join(result)
 
 
 def remove_tags(
@@ -251,13 +291,10 @@ def remove_tags(
     if which_ones and keep:
         raise ValueError("Cannot use both which_ones and keep")
 
-    return _tags_re.sub(
-        functools.partial(
-            _remove_tag,
-            which_ones={tag.lower() for tag in which_ones} if which_ones else (),
-            keep={tag.lower() for tag in keep} if keep else (),
-        ),
+    return _remove_tags(
         to_unicode(text, encoding),
+        which_ones={tag.lower() for tag in which_ones} if which_ones else (),
+        keep={tag.lower() for tag in keep} if keep else (),
     )
 
 


### PR DESCRIPTION
Fixes #284.

## Reproduction
On current `master`, `remove_tags('<a title="x>y">texty</a>')` returns `y">texty` because tag matching stops at the `>` inside the quoted attribute value. The same happens for single-quoted attribute values.

## Root cause
`remove_tags` used a regular expression that treated every raw `>` as the end of a tag. That cuts valid tags in the middle when quoted attributes contain `>`, leaking the tail of the opening tag into the output.

## Fix
Replace the `remove_tags` tag regex with a small linear scanner that reads the tag name and ignores `>` while inside a quoted attribute value that starts after `=`. Quotes in unquoted attribute values keep the previous behavior, so malformed inputs such as `<a b=c"d>keep</a>` are still handled as before.

## Compatibility notes
This changes `remove_tags` behavior only for valid tags whose quoted attribute values contain `>`. Existing `which_ones` and `keep` filtering is preserved.

## Validation
- Regression check with the fix reverted: `python -m pytest tests\test_html.py::TestRemoveTags::test_remove_tags_with_gt_in_quoted_attribute tests\test_html.py::TestRemoveTags::test_remove_tags_with_unquoted_quote_in_attribute -q` -> 1 failed, 1 passed (expected failure: `y">texty` vs `texty`).
- Targeted tests: `python -m pytest tests\test_html.py::TestRemoveTags -q` -> 11 passed.
- Full test suite: `python -m pytest` -> 409 passed, 4 skipped, 74 xfailed.
- Lint on touched files: `python -m ruff check w3lib\html.py tests\test_html.py` -> all checks passed.
- Formatting check on touched files: `python -m ruff format --check w3lib\html.py tests\test_html.py` -> 2 files already formatted.
- Type check: `python -m mypy w3lib tests` -> success, no issues in 20 source files.