### PR TITLE
 Decode a lead 0x80 as the euro sign in GB18030

### DIFF
--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -5,6 +5,8 @@ import random
 from io import BytesIO
 from typing import Any
 
+import pytest
+
 from w3lib.encoding import (
     html_body_declared_encoding,
     html_to_unicode,
@@ -161,6 +163,20 @@ class TestUnicodeDecoding:
 
     def test_invalid_utf8(self):
         assert to_unicode(b"\xc2\xc2\xa3", "utf-8") == "\ufffd\xa3"
+
+    @pytest.mark.parametrize(
+        ("data", "expected"),
+        [
+            (b"\x80", "\u20ac"),
+            (b"100\x80", "100\u20ac"),
+            (b"\xff\x80", "\ufffd\u20ac"),
+            (b"\x81\x80", "\u4e90"),
+            (b"\xa2\xe3", "\u20ac"),
+            (b"\xff", "\ufffd"),
+        ],
+    )
+    def test_gb18030(self, data: bytes, expected: str) -> None:
+        assert to_unicode(data, "gb18030") == expected
 
 
 def ct(charset: str | None) -> str | None:

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -164,6 +164,7 @@ class TestUnicodeDecoding:
     def test_invalid_utf8(self):
         assert to_unicode(b"\xc2\xc2\xa3", "utf-8") == "\ufffd\xa3"
 
+    @pytest.mark.parametrize("encoding", ["gb18030", "GB18030", "gb18030_2000"])
     @pytest.mark.parametrize(
         ("data", "expected"),
         [
@@ -175,8 +176,8 @@ class TestUnicodeDecoding:
             (b"\xff", "\ufffd"),
         ],
     )
-    def test_gb18030(self, data: bytes, expected: str) -> None:
-        assert to_unicode(data, "gb18030") == expected
+    def test_gb18030(self, data: bytes, expected: str, encoding: str) -> None:
+        assert to_unicode(data, encoding) == expected
 
 
 def ct(charset: str | None) -> str | None:

--- a/w3lib/encoding.py
+++ b/w3lib/encoding.py
@@ -214,13 +214,31 @@ codecs.register_error(
 )
 
 
+def _gb18030_replace(exc: UnicodeError) -> tuple[str, int]:
+    error = cast("AnyUnicodeError", exc)
+    if error.object[error.start] == 0x80:
+        return "\u20ac", error.start + 1
+    return "\ufffd", error.end
+
+
+# The GB18030 decoder of the Encoding Standard decodes a lead 0x80 as the euro
+# sign, for GBK compatibility, while the Python codec rejects it.
+# https://encoding.spec.whatwg.org/#gb18030-decoder
+codecs.register_error("w3lib_gb18030_replace", _gb18030_replace)
+
+
 def to_unicode(data_str: bytes, encoding: str) -> str:
     r"""Convert a str object to unicode using the encoding given
 
     Characters that cannot be converted will be converted to ``\ufffd`` (the
     unicode replacement character).
     """
-    return data_str.decode(encoding, "replace")
+    errors = (
+        "w3lib_gb18030_replace"
+        if codecs.lookup(encoding).name == "gb18030"
+        else "replace"
+    )
+    return data_str.decode(encoding, errors)
 
 
 def html_to_unicode(

--- a/w3lib/encoding.py
+++ b/w3lib/encoding.py
@@ -233,9 +233,11 @@ def to_unicode(data_str: bytes, encoding: str) -> str:
     Characters that cannot be converted will be converted to ``\ufffd`` (the
     unicode replacement character).
     """
+    # Every name that resolves to gb18030 contains "18030", so the substring
+    # check keeps the codec lookup out of the common case.
     errors = (
         "w3lib_gb18030_replace"
-        if codecs.lookup(encoding).name == "gb18030"
+        if "18030" in encoding and codecs.lookup(encoding).name == "gb18030"
         else "replace"
     )
     return data_str.decode(encoding, errors)


### PR DESCRIPTION
Fixes https://github.com/scrapy/w3lib/issues/76