### PR TITLE
remove ascii tab and newline from the url in _urlsplit

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -1661,6 +1661,24 @@ class TestCanonicalizeUrl:
         assert parse_url(url).path == urlparse(url).path
         assert parse_url(url).params == urlparse(url).params
 
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://exa\tmple.com/p",
+            "http://exa\nmple.com/p",
+            "http://exa\rmple.com/p",
+            "https://good.com\t.evil.com/a\r\nb?q=a\tb#f\tr",
+            "http://example.com:8\t0/",
+        ],
+    )
+    def test_parse_url_remove_ascii_tab_and_newlines(self, url):
+        # urlsplit drops every ASCII tab and newline from the URL, so a tab in
+        # the host cannot survive into parse_url()'s netloc and report a host a
+        # browser would not connect to.
+        assert parse_url(url).netloc == urlparse(url).netloc
+        assert parse_url(url).hostname == urlparse(url).hostname
+        assert "\t" not in parse_url(url).netloc
+
     def test_canonicalize_url_non_final_segment_semicolon(self):
         # the path after such a ";" still gets percent-encoding normalization
         assert (

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -14,7 +14,13 @@ from w3lib._infra import (
     _ASCII_TAB_OR_NEWLINE,
     _C0_CONTROL_OR_SPACE,
 )
-from w3lib._url import _SPECIAL_SCHEMES, _split_params, _urlunparse, _urlunsplit
+from w3lib._url import (
+    _SPECIAL_SCHEMES,
+    _split_params,
+    _urlsplit,
+    _urlunparse,
+    _urlunsplit,
+)
 from w3lib.url import (
     add_or_replace_parameter,
     add_or_replace_parameters,
@@ -1678,6 +1684,12 @@ class TestCanonicalizeUrl:
         assert parse_url(url).netloc == urlparse(url).netloc
         assert parse_url(url).hostname == urlparse(url).hostname
         assert "\t" not in parse_url(url).netloc
+
+    def test_urlsplit_remove_ascii_tab_and_newlines_from_scheme(self):
+        # the default-scheme argument gets the same tab/newline removal as the
+        # URL itself, matching urllib.parse.urlsplit
+        assert _urlsplit("//example.com/p", "ht\ttp").scheme == "http"
+        assert _urlsplit("//example.com/p", "ht\ntt\rp").scheme == "htttp"
 
     def test_canonicalize_url_non_final_segment_semicolon(self):
         # the path after such a ";" still gets percent-encoding normalization

--- a/w3lib/_url.py
+++ b/w3lib/_url.py
@@ -644,6 +644,14 @@ def _urlsplit(  # pylint: disable=too-many-locals,too-many-statements
     if not url:
         return _SplitResult(scheme, "", "", "", "")
 
+    # urllib.parse.urlsplit removes every ASCII tab and newline from anywhere in
+    # the URL before parsing (the WHATWG "remove all ASCII tab or newline"
+    # step). This reimplementation only stripped leading C0/space, so a tab or
+    # newline embedded in the authority survived: parse_url("http://exa\tmple.com")
+    # reported host "exa\tmple.com" while urlsplit and browsers drop the tab and
+    # resolve "example.com".
+    url = url.translate(_ASCII_TAB_OR_NEWLINE_TRANSLATION_TABLE)
+    scheme = scheme.translate(_ASCII_TAB_OR_NEWLINE_TRANSLATION_TABLE)
     url, scheme = url.lstrip(_C0_CONTROL_OR_SPACE), scheme.strip(_C0_CONTROL_OR_SPACE)
 
     netloc = query = fragment = ""

--- a/w3lib/_url.py
+++ b/w3lib/_url.py
@@ -649,9 +649,12 @@ def _urlsplit(  # pylint: disable=too-many-locals,too-many-statements
     # step). This reimplementation only stripped leading C0/space, so a tab or
     # newline embedded in the authority survived: parse_url("http://exa\tmple.com")
     # reported host "exa\tmple.com" while urlsplit and browsers drop the tab and
-    # resolve "example.com".
-    url = url.translate(_ASCII_TAB_OR_NEWLINE_TRANSLATION_TABLE)
-    scheme = scheme.translate(_ASCII_TAB_OR_NEWLINE_TRANSLATION_TABLE)
+    # resolve "example.com". The membership checks keep the common tab-free path
+    # free of translate calls and string allocations.
+    if "\t" in url or "\n" in url or "\r" in url:
+        url = url.translate(_ASCII_TAB_OR_NEWLINE_TRANSLATION_TABLE)
+    if "\t" in scheme or "\n" in scheme or "\r" in scheme:
+        scheme = scheme.translate(_ASCII_TAB_OR_NEWLINE_TRANSLATION_TABLE)
     url, scheme = url.lstrip(_C0_CONTROL_OR_SPACE), scheme.strip(_C0_CONTROL_OR_SPACE)
 
     netloc = query = fragment = ""


### PR DESCRIPTION
    parse_url("http://exa\tmple.com/p").hostname  ->  'exa\tmple.com'
    urlparse("http://exa\tmple.com/p").hostname   ->  'example.com'

`_urlsplit` reimplements `urllib.parse.urlsplit` but skips its "remove all ASCII tab or newline" step, only lstripping leading C0/space. A tab, CR or LF left in the authority survives, so `parse_url` (also `url_query_parameter`, `add_or_replace_parameter`) reports a host a browser never connects to; a tabbed port like `http://example.com:8\t0/` raised ValueError where `urlparse` returns port 80. #279 added the strip to `canonicalize_url`'s bytes path only, so `parse_url` still diverged from `urlparse`. Drop tab/CR/LF from the url and scheme at the top of `_urlsplit`, matching `urlsplit`; `safe_url_string`/`canonicalize_url` already `_strip` first and are unchanged.
