### PR TITLE
strip script and noscript content in get_base_url

### DIFF
--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -474,6 +474,33 @@ class TestGetBaseUrl:
             )
             == "http://example.org/found/"
         )
+        # an unterminated <script> swallows the rest of the document, as in a
+        # browser
+        assert (
+            get_base_url(
+                """<script><base href="http://evil.example/">""",
+                baseurl,
+            )
+            == "https://example.org"
+        )
+        assert (
+            get_base_url(
+                """<noscript foo="bar"><base href="http://evil.example/">""",
+                baseurl,
+            )
+            == "https://example.org"
+        )
+
+    def test_base_url_split_by_comment(self):
+        # A comment inside the <base> tag is not stripped: browsers do not
+        # parse comments within a tag, so the tag is broken and ignored.
+        assert (
+            get_base_url(
+                """<base h<!--c-->ref="http://example.com/">""",
+                "https://example.org",
+            )
+            == "https://example.org"
+        )
 
     def test_relative_url_with_absolute_path(self):
         baseurl = "https://example.org"

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -447,6 +447,34 @@ class TestGetBaseUrl:
             == "http://example_3.com/"
         )
 
+    def test_base_url_in_script(self):
+        baseurl = "https://example.org"
+        # A browser does not parse tags inside <script>/<noscript>, so a <base>
+        # written there is ignored and relative URLs resolve against baseurl.
+        assert (
+            get_base_url(
+                """<script>var t = "<base href='http://evil.example/'>";</script>""",
+                baseurl,
+            )
+            == "https://example.org"
+        )
+        assert (
+            get_base_url(
+                """<noscript><base href="http://evil.example/"></noscript>""",
+                baseurl,
+            )
+            == "https://example.org"
+        )
+        # a real <base> after the ignored one is still picked up
+        assert (
+            get_base_url(
+                """<script><base href="http://evil.example/"></script>"""
+                """<base href="http://example.org/found/">""",
+                baseurl,
+            )
+            == "http://example.org/found/"
+        )
+
     def test_relative_url_with_absolute_path(self):
         baseurl = "https://example.org"
         text = """\

--- a/w3lib/html.py
+++ b/w3lib/html.py
@@ -388,7 +388,12 @@ def get_base_url(
 
     """
 
-    utext = remove_comments(text, encoding=encoding)
+    # A browser never parses tags inside <script>/<noscript>, so a <base>
+    # written as text there is ignored; drop that content first (as
+    # get_meta_refresh does) to avoid resolving links against a base URL the
+    # browser does not honor.
+    utext = remove_tags_with_content(text, ("script", "noscript"), encoding=encoding)
+    utext = remove_comments(utext)
     if m := _baseurl_re.search(utext):
         return urljoin(
             safe_url_string(baseurl), safe_url_string(m.group(1), encoding=encoding)

--- a/w3lib/html.py
+++ b/w3lib/html.py
@@ -24,8 +24,18 @@ _ent_re = re.compile(
     re.IGNORECASE,
 )
 _tag_re = re.compile(r"<[a-zA-Z\/!][^<>]*>")
-_baseurl_re = re.compile(
-    r"<base\s[^<>]*href\s*=\s*[\"\']\s*([^\"\'\s]+)\s*[\"\']", re.IGNORECASE
+# Scan for the first honored <base href>, consuming comments and
+# <script>/<noscript> content (where a browser never parses tags) along the
+# way. Ignorable regions come first in the alternation, so a <base> inside one
+# is consumed before it can match; unterminated regions swallow the rest of
+# the document, as a browser does.
+_base_scan_re = re.compile(
+    r"""
+      <!--.*?(?:-->|$)
+    | <(?P<t>script|noscript)\b[^<>]*>.*?(?:</(?P=t)>|$)
+    | <base\s[^<>]*href\s*=\s*["']\s*(?P<url>[^"'\s]+)\s*["']
+    """,
+    re.IGNORECASE | re.DOTALL | re.VERBOSE,
 )
 
 
@@ -388,16 +398,12 @@ def get_base_url(
 
     """
 
-    # A browser never parses tags inside <script>/<noscript>, so a <base>
-    # written as text there is ignored; drop that content first (as
-    # get_meta_refresh does) to avoid resolving links against a base URL the
-    # browser does not honor.
-    utext = remove_tags_with_content(text, ("script", "noscript"), encoding=encoding)
-    utext = remove_comments(utext)
-    if m := _baseurl_re.search(utext):
-        return urljoin(
-            safe_url_string(baseurl), safe_url_string(m.group(1), encoding=encoding)
-        )
+    utext = to_unicode(text, encoding)
+    for m in _base_scan_re.finditer(utext):
+        if url := m.group("url"):
+            return urljoin(
+                safe_url_string(baseurl), safe_url_string(url, encoding=encoding)
+            )
     return safe_url_string(baseurl)
 
 


### PR DESCRIPTION
    >>> get_base_url("<script>var t = \"<base href='http://evil.example/'>\";</script>", "https://good.example/")
    'http://evil.example/'

get_base_url only runs remove_comments before scanning for `<base href>`, so a `<base>` written as text inside `<script>` or `<noscript>` is picked up and used to resolve relative URLs. A browser never parses tags inside those elements, so it ignores such a base and resolves against the real one; a consumer that reflects untrusted markup into a script/noscript block ends up resolving links against an attacker-chosen base.

get_meta_refresh already drops script/noscript for the same reason. This does the same in get_base_url before the search. A `<base>` that follows the ignored content is still returned.