### PR TITLE
skip html comments in html_body_declared_encoding

### DIFF
--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -176,6 +176,13 @@ class TestRequestEncoding:
             )
             == "gb18030"
         )
+        # a charset declared inside a comment is not honored, and a commented
+        # body tag does not stop the scan
+        assert html_body_declared_encoding(b'<!-- <meta charset="utf-7"> -->') is None
+        assert (
+            html_body_declared_encoding(b'<!-- <body> --><meta charset="utf-8">')
+            == "utf-8"
+        )
 
     def test_html_body_declared_encoding_unicode(self):
         # html_body_declared_encoding should work when unicode body is passed

--- a/w3lib/encoding.py
+++ b/w3lib/encoding.py
@@ -75,6 +75,13 @@ def http_content_type_encoding(content_type: str | None) -> str | None:
     return None
 
 
+# Comments are skipped by the WHATWG prescan before it looks for a meta
+# charset, so a declaration written inside one is not honored (and a commented
+# body tag does not stop the scan). The sibling scanners get_base_url and
+# get_meta_refresh strip comments for the same reason; strip them here too.
+_COMMENT_STR_RE = re.compile(r"<!--.*?(?:-->|$)", re.DOTALL)
+_COMMENT_BYTES_RE = re.compile(rb"<!--.*?(?:-->|$)", re.DOTALL)
+
 # Check for a charset in a meta tag or an xml declaration, and stop the search
 # if a body tag is encountered. Any meta tag with a charset counts, however it
 # spells its other attributes, e.g. <meta httpequiv="ContentType"
@@ -116,9 +123,9 @@ def html_body_declared_encoding(html_body_str: str | bytes) -> str | None:
     chunk = html_body_str[:4096]
     match: Match[bytes] | Match[str] | None
     if isinstance(chunk, bytes):
-        match = _BODY_ENCODING_BYTES_RE.search(chunk)
+        match = _BODY_ENCODING_BYTES_RE.search(_COMMENT_BYTES_RE.sub(b"", chunk))
     else:
-        match = _BODY_ENCODING_STR_RE.search(chunk)
+        match = _BODY_ENCODING_STR_RE.search(_COMMENT_STR_RE.sub("", chunk))
 
     if match:
         encoding = match.group("charset") or match.group("xmlcharset")


### PR DESCRIPTION
html_body_declared_encoding scans the start of a body for a `<meta charset>` or an xml encoding declaration and stops at a `<body>` tag, but it never skips HTML comments. The WHATWG prescan skips comment content before it looks for a meta charset, and the sibling scanners in html.py already do the same (get_base_url consumes comments in its scan pattern, get_meta_refresh calls remove_comments first), so this one is the odd one out. Because of that a charset written only inside a comment is treated as declared: `html_body_declared_encoding(b'<!-- <meta charset="utf-7"> -->')` returns utf-7, and a commented-out `<body>` stops the scan and hides a real later declaration so `<!-- <body> --><meta charset="utf-8">` returns None. I hit this going through html_to_unicode with no Content-Type header, where the meta step then picks the commented encoding: a utf-7 comment makes `+ADw-script+AD4-` decode into `<script>`, i.e. attacker markup in a comment choosing the decode. The fix strips comments from the scanned chunk before searching, for both the str and bytes paths, using the same `<!--...-->` (or end of input) shape remove_comments uses so an unterminated comment behaves the same way.
