### PR TITLE
Keep percent-encoded percent signs in canonicalize_url

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -1668,6 +1668,17 @@ class TestCanonicalizeUrl:
         )
         assert canonicalize_url("http://foo.com/AC%2FDC/") == "http://foo.com/AC%2FDC/"
 
+    def test_quoted_percent_sign(self):
+        # a quoted percent sign (%25) must stay encoded, not decode to a bare %
+        assert (
+            canonicalize_url("http://foo.com/cmp/Supermercados-Dia%25")
+            == "http://foo.com/cmp/Supermercados-Dia%25"
+        )
+        assert (
+            canonicalize_url("http://foo.com/100%25/path")
+            == "http://foo.com/100%25/path"
+        )
+
     def test_canonicalize_urlparsed(self):
         # canonicalize_url() can be passed an already urlparse'd URL
         assert (

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -1678,6 +1678,11 @@ class TestCanonicalizeUrl:
             canonicalize_url("http://foo.com/100%25/path")
             == "http://foo.com/100%25/path"
         )
+        # idempotency: second canonicalization must be stable
+        url = "http://foo.com/cmp/Supermercados-Dia%25"
+        assert canonicalize_url(canonicalize_url(url)) == canonicalize_url(url)
+        # double-encoded percent must stay double-encoded
+        assert canonicalize_url("http://foo.com/%2525") == "http://foo.com/%2525"
 
     def test_canonicalize_urlparsed(self):
         # canonicalize_url() can be passed an already urlparse'd URL

--- a/w3lib/url.py
+++ b/w3lib/url.py
@@ -731,7 +731,8 @@ def _unquotepath(path: str) -> bytes:
     # percent-escaped characters, they get lost.
     # e.g., '%a3' becomes 'REPLACEMENT CHARACTER' (U+FFFD)
     return _unquote(
-        path.replace("%2f", "%252F")
+        path.replace("%25", "%2525")
+        .replace("%2f", "%252F")
         .replace("%2F", "%252F")
         .replace("%3f", "%253F")
         .replace("%3F", "%253F")


### PR DESCRIPTION
## Summary

Fixes the `%25` case from #131.

`canonicalize_url()` currently decodes an encoded percent sign in a path:

```python
canonicalize_url("http://example.com/cmp/Supermercados-Dia%25")
# before:
# "http://example.com/cmp/Supermercados-Dia%"
```

That leaves a bare % in the canonicalized path.

This change preserves %25 in `_unquotepath()` using the same mechanism
already used for encoded / (%2F) and ? (%3F).

After the change:

```python
canonicalize_url("http://example.com/cmp/Supermercados-Dia%25")
# "http://example.com/cmp/Supermercados-Dia%25"
```

The result is also stable when canonicalized again.

## Scope

This intentionally fixes only the %25 corruption reported in the original
issue.

Issue #131 also contains discussion about other percent-encoded reserved
characters such as %26. I did not change those semantics here because w3lib
currently has established behavior for some of them; for example, existing
tests intentionally normalize %2C to , while preserving %23.

So this PR does not attempt to redefine the broader reserved-character
normalization policy.

## Previous attempt

#258 proposed the same narrow %25 preservation idea and was closed without a
technical review. I independently reproduced the issue on current master and
validated this change against the current test suite.

## Tests

Added regression coverage for:

- the original Supermercados-Dia%25 case
- %25 within another path
- repeated canonicalization / idempotency

Validation:

- `tests/test_url.py`: 332 passed, 74 xfailed
- full `tests`:        462 passed, 4 skipped, 74 xfailed
- `git diff --check`:  clean

Fixes #131.
