### PR TITLE
reject utf-7 in resolve_encoding

### DIFF
--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -216,6 +216,19 @@ class TestCodecsEncoding:
         assert resolve_encoding(" Latin-1") == "cp1252"
         assert resolve_encoding("gb_2312-80") == "gb18030"
         assert resolve_encoding("unknown encoding") is None
+        # utf-7 is not in the Encoding Standard and enables charset-smuggling,
+        # so it must not resolve, however it is spelled.
+        for alias in ("utf-7", "utf7", "U7", "unicode-1-1-utf-7", "UTF_7"):
+            assert resolve_encoding(alias) is None, alias
+
+    def test_resolve_encoding_utf7_not_smuggled(self):
+        # a utf-7 charset from the header or a meta tag is ignored, so the
+        # "+ADw-script+AD4-" payload stays inert instead of decoding to markup
+        assert http_content_type_encoding("text/html; charset=utf-7") is None
+        assert html_body_declared_encoding(b'<meta charset="utf-7">') is None
+        enc, body = html_to_unicode("text/html; charset=utf-7", b"+ADw-script+AD4-")
+        assert enc != "utf-7"
+        assert "<script>" not in body
 
 
 class TestUnicodeDecoding:

--- a/w3lib/encoding.py
+++ b/w3lib/encoding.py
@@ -188,9 +188,17 @@ def resolve_encoding(encoding_alias: str) -> str | None:
     c18n_encoding = _c18n_encoding(encoding_alias)
     translated = DEFAULT_ENCODING_TRANSLATION.get(c18n_encoding, c18n_encoding)
     try:
-        return codecs.lookup(translated).name
+        name = codecs.lookup(translated).name
     except LookupError:
         return None
+    # UTF-7 has no label in the WHATWG Encoding Standard this module follows and
+    # browsers dropped it. It re-spells "<", ">" and "&" using only ASCII bytes
+    # (e.g. "+ADw-" for "<"), so a response that declares charset=utf-7 lets a
+    # byte sequence a browser shows as inert text decode into live markup. Refuse
+    # it so callers fall back to a safe default instead of the smuggled encoding.
+    if name == "utf-7":
+        return None
+    return name
 
 
 _BOM_TABLE = [


### PR DESCRIPTION
    >>> html_to_unicode("text/html; charset=utf-7", b"+ADw-script+AD4-")
    ('utf-7', '<script>')

resolve_encoding returns any label Python's codecs module knows, so a utf-7
charset from the Content-Type header or a body <meta> is honored. UTF-7 has no
label in the Encoding Standard this module targets and browsers dropped it: it
spells "<" as the ASCII "+ADw-", so a byte sequence a browser shows as inert
text decodes into live markup.

All three attacker-reachable charset sources (http_content_type_encoding,
_quoted_aware_charset, html_body_declared_encoding) go through resolve_encoding,
so the rejection lives there, keyed on the canonical codec name so utf7/U7/
unicode-1-1-utf-7 are covered too. Callers then fall back to their default.