### PR TITLE
Add add_http_if_no_scheme(), ported from Scrapy

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -42,6 +42,7 @@ from w3lib._url import (
     _urlunsplit,
 )
 from w3lib.url import (
+    add_http_if_no_scheme,
     add_or_replace_parameter,
     add_or_replace_parameters,
     any_to_uri,
@@ -955,6 +956,18 @@ class TestUrl:
         assert not is_url("foo://bar")
         assert not is_url("foo--bar")
 
+    def test_add_http_if_no_scheme(self):
+        assert add_http_if_no_scheme("www.example.com") == "http://www.example.com"
+        assert add_http_if_no_scheme("//www.example.com") == "http://www.example.com"
+        assert (
+            add_http_if_no_scheme("https://www.example.com")
+            == "https://www.example.com"
+        )
+        assert (
+            add_http_if_no_scheme("HTTPS://www.example.com")
+            == "HTTPS://www.example.com"
+        )
+
     def test_url_query_parameter(self):
         assert url_query_parameter("product.html?id=200&foo=bar", "id") == "200"
         assert (
@@ -1279,6 +1292,12 @@ class TestSafeDownloadUrlProperties:
     @given(hyp_urls())
     def test_no_exception(self, url: str) -> None:
         safe_download_url(url)
+
+
+class TestAddHttpIfNoSchemeProperties:
+    @given(st.text() | hyp_urls())
+    def test_no_exception(self, url: str) -> None:
+        add_http_if_no_scheme(url)
 
 
 class TestIsUrlProperties:

--- a/w3lib/url.py
+++ b/w3lib/url.py
@@ -507,6 +507,14 @@ def any_to_uri(uri_or_path: str) -> str:
     return uri_or_path if _urlparse(uri_or_path)[0] else path_to_file_uri(uri_or_path)
 
 
+def add_http_if_no_scheme(url: str) -> str:
+    """Add ``http`` as the default scheme if it is missing from *url*."""
+    if not re.match(r"^\w+://", url, flags=re.IGNORECASE):
+        scheme = "http:" if _urlparse(url).netloc else "http://"
+        url = scheme + url
+    return url
+
+
 # ASCII characters.
 _char = set(map(chr, range(127)))
 
@@ -600,6 +608,7 @@ def parse_data_uri(uri: str | bytes) -> ParseDataURIResult:
 
 
 __all__ = [
+    "add_http_if_no_scheme",
     "add_or_replace_parameter",
     "add_or_replace_parameters",
     "any_to_uri",


### PR DESCRIPTION
Once merged and released:
- [x] Update scrapy to deprecate its use when using the new w3lib version and higher, and close https://github.com/scrapy/scrapy/issues/2186 with that PR. Drafted at https://github.com/scrapy/scrapy/pull/8189.