### PR TITLE
skip ">" inside quoted attributes in remove_tags and replace_tags

### DIFF
--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -134,11 +134,33 @@ class TestReplaceTags:
             == "Click here"
         )
 
+    def test_replace_tags_gt_in_attribute(self):
+        # A ">" inside a quoted attribute value does not end the tag.
+        assert replace_tags('<a title="x>y">t</a>') == "t"
+        assert replace_tags("<a title='x>y'>t</a>") == "t"
+        assert replace_tags('<a title = "x>y">t</a>') == "t"
+        # A quote that does not open a value (not right after "=") stays an
+        # ordinary character, so the tag still ends at the first ">".
+        assert replace_tags('<a b=c"d>keep</a>') == "keep"
+
     def test_replace_tags_no_catastrophic_backtracking(self):
         evil = "<a" * 50000
         start = time.perf_counter()
         assert replace_tags(evil) == evil  # incomplete tags (no ">") are untouched
         assert replace_tags(evil + "<b>x</b>") == evil + "x"
+        assert time.perf_counter() - start < 2
+
+    @pytest.mark.parametrize(
+        "evil",
+        [
+            pytest.param("<a " + '="' * 100000, id="eq-quote"),
+            pytest.param("<a " + '= "' * 100000, id="eq-space-quote"),
+            pytest.param("<a " + 'a="b' * 100000, id="attr-run"),
+        ],
+    )
+    def test_replace_tags_no_catastrophic_backtracking_quotes(self, evil: str) -> None:
+        start = time.perf_counter()
+        replace_tags(evil)
         assert time.perf_counter() - start < 2
 
 
@@ -234,6 +256,15 @@ class TestRemoveTags:
             == ""
         )
 
+    def test_remove_tags_gt_in_attribute(self):
+        # A ">" inside a quoted attribute value does not end the tag.
+        assert remove_tags('<a title="x>y">t</a>') == "t"
+        assert remove_tags("<a title='x>y'>t</a>") == "t"
+        assert remove_tags('<p title="a>b" class="c">x</p>', which_ones=("p",)) == "x"
+        # A quote that does not open a value (not right after "=") stays an
+        # ordinary character, so the tag still ends at the first ">".
+        assert remove_tags('<a b=c"d>keep</a>') == "keep"
+
     @pytest.mark.parametrize(
         "evil",
         [
@@ -245,6 +276,19 @@ class TestRemoveTags:
         start = time.perf_counter()
         assert remove_tags(evil) == evil
         assert remove_tags(evil + "<b>x</b>") == evil + "x"
+        assert time.perf_counter() - start < 2
+
+    @pytest.mark.parametrize(
+        "evil",
+        [
+            pytest.param("<a " + '="' * 100000, id="eq-quote"),
+            pytest.param("<a " + '= "' * 100000, id="eq-space-quote"),
+            pytest.param("<a " + 'a="b' * 100000, id="attr-run"),
+        ],
+    )
+    def test_remove_tags_no_catastrophic_backtracking_quotes(self, evil: str) -> None:
+        start = time.perf_counter()
+        remove_tags(evil)
         assert time.perf_counter() - start < 2
 
 

--- a/w3lib/html.py
+++ b/w3lib/html.py
@@ -23,7 +23,13 @@ _ent_re = re.compile(
     r"&((?P<named>[a-z0-9]+)|#(?P<dec>[0-9]+)|#x(?P<hex>[a-f0-9]+))(?P<semicolon>;?)",
     re.IGNORECASE,
 )
-_tag_re = re.compile(r"<[a-zA-Z\/!][^<>]*>")
+# A tag body runs up to the first ">" that is not inside a quoted attribute
+# value. A quote only opens a value right after "=" (optionally after
+# whitespace); a quote anywhere else is an ordinary character, so "<a b=c"d>" is
+# a single tag. The (?=...) split makes the choice after "=" unambiguous, so the
+# scan stays linear on adversarial input instead of backtracking on quotes.
+_TAG_BODY = r'(?:[^<>=]|=(?:[ \t\r\n\f]*(?:"[^"]*"|\'[^\']*\')|(?![ \t\r\n\f]*["\'])))*'
+_tag_re = re.compile(r"<[a-zA-Z/!]" + _TAG_BODY + r">")
 # Scan for the first honored <base href>, consuming comments and
 # <script>/<noscript> content (where a browser never parses tags) along the
 # way. Ignorable regions come first in the alternation, so a <base> inside one
@@ -77,7 +83,9 @@ _tags_re = re.compile(
     (?![^ <>/])     # pinned to its maximal length by this lookahead so it can't
                     # overlap the run below and backtrack quadratically on an
                     # unterminated tag (a "<" with a long run and no ">")
-    [^<>]*          # the rest of the tag: attributes, whitespace, etc.
+    """
+    + _TAG_BODY  # the rest of the tag, skipping ">" inside quoted attributes
+    + r"""
     >               # closing angle bracket
     """,
     re.IGNORECASE | re.VERBOSE,


### PR DESCRIPTION
    >>> remove_tags('<a title="x>y">t</a>')
    'y">t'                # expected 't'

`_tag_re` and `_tags_re` match a tag body as `[^<>]*`, which stops at the first
`>`. A `>` is legal inside a quoted attribute value, so the tag is cut
mid-attribute and the trailing fragment is emitted as text, reported in #284.

The obvious quote-aware pattern backtracks catastrophically (also noted in the
issue), so the shared body only lets a quote open a value right after `=`; a
quote in any other position stays an ordinary character, so `<a b=c"d>` remains
a single tag. The zero-width `(?=...)` split after `=` keeps the choice
deterministic, so the scan is linear on adversarial input.

Verified with a differential over random tag-like input: the output changes
only when a quoted attribute value is opened, never otherwise. Regression tests
cover both the `>`-in-attribute cases and the linear-time behavior on
`="`-repeated input.
