### PR TITLE
Treat surrogate character references as illegal in replace_entities

### DIFF
--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -80,8 +80,8 @@ class TestRemoveEntities:
         # The result must always be encodable (regression check).
         replace_entities("&#xD800;", remove_illegal=False).encode("utf-8")
         # Code points just outside the surrogate range remain valid.
-        assert replace_entities("x&#xE000;y") == "xy"
-        assert replace_entities("x&#xD7FF;y") == "x퟿y"
+        assert replace_entities("x&#xE000;y") == "x\ue000y"
+        assert replace_entities("x&#xD7FF;y") == "x\ud7ffy"
 
     def test_browser_hack(self):
         # check browser hack for numeric character references in the 80-9F range

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -70,6 +70,18 @@ class TestRemoveEntities:
         assert (
             replace_entities("&#82179209091;", remove_illegal=False) == "&#82179209091;"
         )
+        # Surrogate code points (U+D800-U+DFFF) are not valid Unicode scalar
+        # values; they used to be returned as un-encodable lone surrogates.
+        # They are now treated as illegal, like out-of-range references.
+        assert replace_entities("x&#xD800;y") == "xy"
+        assert replace_entities("x&#xDFFF;y") == "xy"
+        assert replace_entities("x&#55296;y") == "xy"  # U+D800 in decimal
+        assert replace_entities("x&#xD800;y", remove_illegal=False) == "x&#xD800;y"
+        # The result must always be encodable (regression check).
+        replace_entities("&#xD800;", remove_illegal=False).encode("utf-8")
+        # Code points just outside the surrogate range remain valid.
+        assert replace_entities("x&#xE000;y") == "xy"
+        assert replace_entities("x&#xD7FF;y") == "x퟿y"
 
     def test_browser_hack(self):
         # check browser hack for numeric character references in the 80-9F range

--- a/w3lib/html.py
+++ b/w3lib/html.py
@@ -147,7 +147,13 @@ def replace_entities(
             try:
                 if 0x80 <= number <= 0x9F:
                     return bytes((number,)).decode("cp1252")
-                return chr(number)
+                # Surrogate code points (U+D800-U+DFFF) are not valid Unicode
+                # scalar values. chr() accepts them but returns a lone surrogate
+                # that cannot be encoded (e.g. to UTF-8), which breaks callers.
+                # Treat them as illegal, the same as the out-of-range references
+                # handled by the except clause below.
+                if not 0xD800 <= number <= 0xDFFF:
+                    return chr(number)
             except (ValueError, OverflowError):
                 pass
 


### PR DESCRIPTION
## Problem

A numeric character reference pointing at a **surrogate code point** (U+D800–U+DFFF), such as `&#xD800;`, is passed directly to `chr()`. `chr()` accepts surrogates and returns a *lone surrogate*. That is still a `str`, but not a valid Unicode scalar value, so it cannot be encoded:

```pycon
>>> from w3lib.html import replace_entities
>>> replace_entities("&#xD800;")
'\ud800'
>>> replace_entities("&#xD800;").encode("utf-8")
UnicodeEncodeError: 'utf-8' codec can't encode character '\ud800' in position 0: surrogates not allowed
```

Any caller that later encodes the cleaned text (very common) then crashes.

## Fix

Treat surrogate code points as illegal, the same way out-of-range references are already handled by the surrounding `try/except`. Surrogates do not raise from `chr()`, so they need an explicit guard.

Result: `&#xD800;` is removed when `remove_illegal=True` (default) and kept verbatim when `remove_illegal=False` — consistent with the existing behaviour for other invalid numeric references. Valid code points on either side of the range (U+D7FF, U+E000) are unaffected.

## Tests

Added regression cases to `test_illegal_entities` (hex + decimal surrogates, both `remove_illegal` modes, boundary code points, and an `encode()` check). Verified they fail before the change and pass after; full suite green (471 passed).

Happy to add a NEWS entry if you'd like — I left it out since there's no unreleased section yet.