### PR TITLE
Drop the unused w3lib_replace error hanlder.

### DIFF
--- a/w3lib/encoding.py
+++ b/w3lib/encoding.py
@@ -240,13 +240,6 @@ def read_bom(data: bytes) -> tuple[None, None] | tuple[str, bytes]:
     return None, None
 
 
-# Python decoder doesn't follow unicode standard when handling
-# bad utf-8 encoded strings. see http://bugs.python.org/issue8271
-codecs.register_error(
-    "w3lib_replace", lambda exc: ("\ufffd", cast("AnyUnicodeError", exc).end)
-)
-
-
 def _gb18030_replace(exc: UnicodeError) -> tuple[str, int]:
     error = cast("AnyUnicodeError", exc)
     if error.object[error.start] == 0x80:


### PR DESCRIPTION
It was used for Python <= 3.2 and the related code was removed in #175