### PR TITLE
resolve percent-encoded dot segments in safe_download_url

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -980,6 +980,30 @@ class TestUrl:
             == "http://www.example.org/%A3?%C2%A3"
         )
 
+    def test_safe_download_url_encoded_dot_segments(self):
+        # "%2e", ".%2e", "%2e." and "%2e%2e" are the percent-encoded forms of
+        # the single-dot and double-dot path segments of the URL living
+        # standard, resolved by clients like "." and "..".
+        assert (
+            safe_download_url("http://www.example.org/dir/%2e%2e/secret")
+            == "http://www.example.org/secret"
+        )
+        assert (
+            safe_download_url(
+                "http://www.example.org/%2E%2E/%2E%2E/images/%2e%2e/image"
+            )
+            == "http://www.example.org/image"
+        )
+        assert (
+            safe_download_url("http://www.example.org/dir/.%2e/%2e./a/%2e/b")
+            == "http://www.example.org/a/b"
+        )
+        # Segments that merely contain "%2e" are not dot segments.
+        assert (
+            safe_download_url("http://www.example.org/a%2eb/%2ec/")
+            == "http://www.example.org/a%2eb/%2ec/"
+        )
+
     def test_is_url(self):
         assert is_url("http://www.example.org")
         assert is_url("https://www.example.org")

--- a/w3lib/url.py
+++ b/w3lib/url.py
@@ -221,6 +221,15 @@ def safe_url_string(
 
 _parent_dirs = re.compile(r"/?(\.\./)+")
 
+# Percent-encoded forms of the single-dot and double-dot path segments of the
+# URL living standard, which clients resolve like "." and "..".
+_encoded_dot_segments = {
+    "%2e": ".",
+    ".%2e": "..",
+    "%2e.": "..",
+    "%2e%2e": "..",
+}
+
 
 def safe_download_url(
     url: str | bytes, encoding: str = "utf8", path_encoding: str = "utf8"
@@ -235,6 +244,11 @@ def safe_download_url(
     safe_url = safe_url_string(url, encoding, path_encoding)
     scheme, netloc, path, query, _ = _urlsplit(safe_url)
     if path:
+        if "%" in path:
+            path = "/".join(
+                _encoded_dot_segments.get(segment.lower(), segment)
+                for segment in path.split("/")
+            )
         normalized_path = _parent_dirs.sub("", posixpath.normpath(path))
         if path.endswith("/") and not normalized_path.endswith("/"):
             normalized_path = f"{normalized_path}/"


### PR DESCRIPTION
    >>> safe_download_url("http://www.example.org/dir/%2e%2e/secret")
    'http://www.example.org/dir/%2e%2e/secret'

`%2e`, `.%2e`, `%2e.` and `%2e%2e` are single/double-dot path segments under the URL living standard (ASCII case-insensitive), so a compliant client resolves that URL to `/secret`, outside `/dir/`: the traversal the function is documented to neutralize survives in encoded form, while its literal spelling `/dir/../secret` is stripped. `canonicalize_url` already resolves these because it percent-decodes the path before `normpath`. Here the encoded dot segments are decoded segment-wise before `normpath`, behind a `"%" in path` test so percent-free paths keep the current path untouched; segments that merely contain `%2e` (e.g. `a%2eb`) are left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XHtkcqVANsVciDasEK5Ys1