### PR TITLE
emit U+FFFD for null and surrogate references in replace_entities

### DIFF
--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -87,6 +87,19 @@ class TestRemoveEntities:
         # the named reference still ends where the ASCII digits do
         assert replace_entities("&nbsp\u0664;") == "\xa0\u0664;"
 
+    def test_null_and_surrogate_references(self):
+        # the tokenizer resolves a null or surrogate reference to U+FFFD; chr()
+        # would emit a NUL or a lone surrogate, which cannot be UTF-8 encoded
+        assert replace_entities("a&#0;b") == "a\ufffdb"
+        assert replace_entities("a&#x0;b", remove_illegal=False) == "a\ufffdb"
+        assert replace_entities("&#xD800;") == "\ufffd"
+        assert replace_entities("&#xdfff;") == "\ufffd"
+        assert replace_entities("&#55296;", remove_illegal=False) == "\ufffd"
+        assert replace_entities("&#xD800") == "\ufffd"
+        # the neighbours of the surrogate range are ordinary code points
+        assert replace_entities("&#xD7FF;&#xE000;") == "\ud7ff\ue000"
+        assert replace_entities("&#xD800;").encode("utf-8") == b"\xef\xbf\xbd"
+
     def test_missing_semicolon(self):
         for entity, result in (
             ("&lt&lt!", "<<!"),
@@ -683,6 +696,13 @@ class TestGetMetaRefresh:
         baseurl = "http://example.org"
         body = """<meta http-equiv="refresh" content="٥; url=http://example.org/x">"""
         assert get_meta_refresh(body, baseurl) == (None, None)
+
+    def test_surrogate_reference_in_url(self):
+        # a surrogate reference in the URL resolves to U+FFFD, as in a browser,
+        # instead of a lone surrogate that safe_url_string cannot encode
+        baseurl = "http://example.org"
+        body = """<meta http-equiv="refresh" content="0;url=/a&#xD800;b">"""
+        assert get_meta_refresh(body, baseurl) == (0, "http://example.org/a%EF%BF%BDb")
 
     def test_relative_redirects(self):
         # relative redirects

--- a/w3lib/html.py
+++ b/w3lib/html.py
@@ -140,6 +140,13 @@ def replace_entities(
                 entity_name.lower()
             )
         if number is not None:
+            # A null or surrogate reference is a parse error that the tokenizer
+            # resolves to U+FFFD; chr() would instead emit a NUL or a lone
+            # surrogate, which is not a Unicode scalar value and fails to
+            # encode. Out-of-range references keep the remove_illegal handling.
+            # https://html.spec.whatwg.org/commit-snapshots/3e7b72c44ce144cee7db859cd0647af6646b6793/#numeric-character-reference-end-state
+            if number == 0 or 0xD800 <= number <= 0xDFFF:
+                return "\ufffd"
             # Numeric character references in the 80-9F range are typically
             # interpreted by browsers as representing the characters mapped
             # to bytes 80-9F in the Windows-1252 encoding. For more info


### PR DESCRIPTION
get_meta_refresh on a page whose refresh URL carries a surrogate character reference:

    >>> get_meta_refresh('<meta http-equiv="refresh" content="0;url=/a&#xD800;b">', "http://example.org/")
    Traceback (most recent call last):
      File "w3lib/html.py", line 448, in get_meta_refresh
        url = safe_url_string(m.group("url").strip(" \"'"), encoding)
      File "w3lib/url.py", line 219, in safe_url_string
        return _urlunsplit(*_safe_url_split(url, encoding, path_encoding, quote_path))
      File "w3lib/url.py", line 138, in _safe_url_split
        _quote_into(parts.path.encode(path_encoding), tmp_buf, _PATH_SAFEST_CHARS)
    UnicodeEncodeError: 'utf-8' codec can't encode character '\ud800' in position 2: surrogates not allowed

replace_entities resolves numeric references with chr(), so `&#xD800;` through `&#xDFFF;` come back as a lone surrogate (not a Unicode scalar value, so the returned str cannot be UTF-8 encoded anywhere downstream) and `&#0;` as a raw NUL. The tokenizer's [numeric character reference end state](https://html.spec.whatwg.org/commit-snapshots/3e7b72c44ce144cee7db859cd0647af6646b6793/#numeric-character-reference-end-state) resolves both to U+FFFD, as html.unescape does; return that before the chr() call. Out-of-range references keep the existing remove_illegal handling that test_illegal_entities pins.
