### PR TITLE
Keep %3B percent-encoded in canonicalize_url().

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -1798,6 +1798,22 @@ class TestCanonicalizeUrl:
         # double-encoded percent must stay double-encoded
         assert canonicalize_url("http://foo.com/%2525") == "http://foo.com/%2525"
 
+    def test_quoted_semicolon(self):
+        # a quoted semicolon (%3B) must stay encoded
+        assert canonicalize_url("http://foo.com/x%3B") == "http://foo.com/x%3B"
+        assert canonicalize_url("http://foo.com/%3b") == "http://foo.com/%3B"
+        # idempotency: second canonicalization must be stable
+        for url in (
+            "http://foo.com/x%3B",
+            "http://foo.com/%0A%3BpE%7C",
+        ):
+            once = canonicalize_url(url)
+            assert canonicalize_url(once) == once
+        # an unencoded semicolon still marks a params component
+        assert canonicalize_url("http://foo.com/x;b") == "http://foo.com/x;b"
+        # double-encoded semicolon must stay double-encoded
+        assert canonicalize_url("http://foo.com/%253B") == "http://foo.com/%253B"
+
     def test_canonicalize_urlparsed(self):
         # canonicalize_url() can be passed an already urlparse'd URL
         assert (

--- a/w3lib/url.py
+++ b/w3lib/url.py
@@ -794,6 +794,8 @@ def _unquotepath(path: str) -> bytes:
         path.replace("%25", "%2525")
         .replace("%2f", "%252F")
         .replace("%2F", "%252F")
+        .replace("%3b", "%253B")
+        .replace("%3B", "%253B")
         .replace("%3f", "%253F")
         .replace("%3F", "%253F")
     )


### PR DESCRIPTION
Found with hypothesis locally, and like #306 it seems to solve a part of #131 (which I just reopened). Not sure if we need to go through all chars in the last report of #131 and do the same.