### PR TITLE
Fix Windows UNC file URI round trips

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -1290,6 +1290,41 @@ class TestUrl:
         assert x.startswith("file:///")
         assert file_uri_to_path(x).lower() == str(Path(fn).absolute()).lower()
 
+    @pytest.mark.skipif(os.name != "nt", reason="Windows UNC paths")
+    @pytest.mark.parametrize(
+        ("path", "uri"),
+        [
+            (r"\\server\share\file.txt", "file://server/share/file.txt"),
+            (
+                r"\\server\shared folder\café #1.txt",
+                "file://server/shared%20folder/caf%C3%A9%20%231.txt",
+            ),
+        ],
+    )
+    def test_path_to_file_uri_unc(self, path, uri):
+        assert path_to_file_uri(path) == uri
+        assert path_to_file_uri(Path(path)) == uri
+        assert file_uri_to_path(path_to_file_uri(path)) == path
+
+    @pytest.mark.skipif(os.name != "nt", reason="Windows UNC paths")
+    @pytest.mark.parametrize(
+        ("uri", "path"),
+        [
+            ("file://server/share/file.txt", r"\\server\share\file.txt"),
+            (
+                "file://server/shared%20folder/caf%C3%A9%20%231.txt",
+                r"\\server\shared folder\café #1.txt",
+            ),
+            ("//server/share/file.txt", r"\\server\share\file.txt"),
+        ],
+    )
+    def test_file_uri_to_path_unc(self, uri, path):
+        assert file_uri_to_path(uri) == path
+
+    @pytest.mark.parametrize("host", ["localhost", "LOCALHOST"])
+    def test_file_uri_to_path_localhost(self, host):
+        assert file_uri_to_path(f"file://{host}/foo/bar") == f"{os.sep}foo{os.sep}bar"
+
     def test_file_uri_to_path(self):
         if os.name == "nt":
             assert (

--- a/w3lib/url.py
+++ b/w3lib/url.py
@@ -504,14 +504,21 @@ def path_to_file_uri(path: str | os.PathLike[str]) -> str:
     """Convert local filesystem path to legal File URIs as described in:
     http://en.wikipedia.org/wiki/File_URI_scheme
     """
-    return f"file:///{pathname2url(str(Path(path).absolute())).lstrip('/')}"
+    absolute_path = Path(path).absolute()
+    if os.name == "nt" and absolute_path.drive.startswith("\\\\"):
+        return absolute_path.as_uri()
+    return f"file:///{pathname2url(str(absolute_path)).lstrip('/')}"
 
 
 def file_uri_to_path(uri: str) -> str:
     """Convert File URI to local filesystem path according to:
     http://en.wikipedia.org/wiki/File_URI_scheme
     """
-    return _url2pathname(_urlparse(uri)[2])
+    parsed = _urlparse(uri)
+    path = parsed.path
+    if os.name == "nt" and parsed.netloc and parsed.netloc.lower() != "localhost":
+        path = f"//{parsed.netloc}{path}"
+    return _url2pathname(path)
 
 
 def any_to_uri(uri_or_path: str) -> str:


### PR DESCRIPTION
On Windows, `path_to_file_uri(r"\\server\share\file.txt")` currently returns `file:///server/share/file.txt`, treating the server as part of a local path. Conversely, `file_uri_to_path("file://server/share/file.txt")` discards the server and returns `\share\file.txt`.

Preserve the UNC server as the URI authority, so the path converts to `file://server/share/file.txt` and back. Use `Path.as_uri()` for Windows UNC paths and retain remote authorities when decoding on Windows. Existing local path conversion and localhost handling remain intact. The representation follows the mapping described in [RFC 8089, Appendix E.3.1](https://www.rfc-editor.org/rfc/rfc8089.html#appendix-E.3.1).

Regression tests cover string and `Path` inputs, round trips, spaces, Unicode, a hash in the filename, scheme-relative UNC references, and localhost casing. They use path conversion only and do not access network shares.

Validation:

- Before the fix: 5 UNC regression cases failed; 2 localhost compatibility cases passed.
- After the fix: 10 focused URI tests passed.
- Full suite with doctests on Windows CPython 3.10, 3.12, and 3.14: 513 passed, 9 skipped, 74 xfailed on each version.
- Ruff 0.15.12 check and format check passed; mypy 2.3.0 passed for all 21 source files.
- Pylint 4.0.5, Sphinx with warnings treated as errors, sdist build, and Twine check passed.
- The parallel suite with coverage and `PYTHONHASHSEED=0` passed: 513 passed, 1 skipped, 74 xfailed; 99% coverage.
- Seven pre-commit hooks passed across all files. The YAML formatter could not execute on Windows (WinError 193); actionlint and zizmor were not completed locally. CI still needs to run those workflow/YAML checks and the remaining OS/Python matrix.

AI assistance: OpenAI Codex helped investigate the bug, write the patch and regression tests, run validation, and draft this description. The added code and tests were written for this contribution; no third-party implementation was copied.
