### PR TITLE
Decode byte URLs in url_query_parameter

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -1040,6 +1040,19 @@ class TestUrl:
             == "200"
         )
 
+    @pytest.mark.parametrize(
+        ("url", "expected"),
+        [
+            (b"product.html?id=200", "200"),
+            (b"product.html?id=", ""),
+            (b"product.html?id=caf%C3%A9", "café"),
+            ("product.html?id=café".encode(), "café"),
+            (b"product.html?other=1&id=200", "200"),
+        ],
+    )
+    def test_url_query_parameter_bytes(self, url: bytes, expected: str) -> None:
+        assert url_query_parameter(url, "id", keep_blank_values=True) == expected
+
     @pytest.mark.xfail
     def test_url_query_parameter_2(self):
         """

--- a/w3lib/url.py
+++ b/w3lib/url.py
@@ -322,7 +322,7 @@ def url_query_parameter(
     """
 
     queryparams = _parse_qs(
-        _urlsplit(str(url)).query,
+        _urlsplit(to_unicode(url)).query,
         keep_blank_values=bool(keep_blank_values),
         separator=separator.encode(),
     )


### PR DESCRIPTION
`url_query_parameter(b"product.html?id=200", "id")` currently returns `"200'"`. Converting a byte URL with `str()` parses its Python representation, including the closing quote, rather than its contents. This also breaks empty values and non-ASCII text.

Decode the URL with `to_unicode`, consistent with the other URL helpers. Added five regression cases covering the final query parameter, blank values, percent-encoded Unicode, and raw UTF-8 bytes; all five fail before the fix.

Validation: 511 tests passed, 1 skipped, 74 xfailed (including doctests, Python 3.14; fixed `PYTHONHASHSEED=0` for stable xdist collection). Ruff check/format and mypy passed.
